### PR TITLE
Added the 'sequential' option to the Blender add-on

### DIFF
--- a/plugins/blender/addons/cgru_tools/__init__.py
+++ b/plugins/blender/addons/cgru_tools/__init__.py
@@ -52,6 +52,9 @@ class ORESettings(bpy.types.PropertyGroup):
 		description='Job Name. Scene name if empty.', maxlen=512, default='')
 	fpertask = IntProperty(name='Per Task', description='Frames Per One Task',
 		min=1, default=1)
+	sequential = IntProperty(name='Sequential',
+		description='Solve task with this step at first.',
+		default=1)
 	pause = BoolProperty(name='Start Job Paused',
 		description='Send job in offline state.', default=0)
 	packLinkedObjects = BoolProperty(name='Pack Linked Objects',

--- a/plugins/blender/addons/cgru_tools/afanasy_tools.py
+++ b/plugins/blender/addons/cgru_tools/afanasy_tools.py
@@ -63,18 +63,16 @@ class RENDER_PT_Afanasy(bpy.types.Panel):
 		col.prop(ore, 'packTextures')
 
 		layout.separator()
-		col = layout.column(align=True)
-		row = col.row(align=True)
-		row.scale_y = 1.4
-		row.prop(sce, 'frame_start')
-		row.prop(sce, 'frame_end')
-		row.prop(sce, 'frame_step')
-		row.prop(ore, 'fpertask')
-		row = col.row(align=True)
-		row.scale_y = 1.2
-		row.prop(ore, 'priority')
-		row.prop(ore, 'maxruntasks')
-		row.prop(ore, 'sequential')
+		row = layout.row(align=False)
+		col = row.column(align=True)
+		col.prop(sce, 'frame_start')
+		col.prop(sce, 'frame_end')
+		col.prop(sce, 'frame_step')
+		col = row.column(align=True)
+		col.prop(ore, 'fpertask')
+		col.prop(ore, 'sequential')
+		col.prop(ore, 'priority')
+		col.prop(ore, 'maxruntasks')
 
 		layout.separator()
 		col = layout.column()

--- a/plugins/blender/addons/cgru_tools/afanasy_tools.py
+++ b/plugins/blender/addons/cgru_tools/afanasy_tools.py
@@ -74,6 +74,7 @@ class RENDER_PT_Afanasy(bpy.types.Panel):
 		row.scale_y = 1.2
 		row.prop(ore, 'priority')
 		row.prop(ore, 'maxruntasks')
+		row.prop(ore, 'sequential')
 
 		layout.separator()
 		col = layout.column()
@@ -171,6 +172,7 @@ class ORE_Submit(bpy.types.Operator):
 		fend = sce.frame_end
 		finc = sce.frame_step
 		fpertask = ore.fpertask
+		sequential = ore.sequential
 
 		# Check frames settings:
 		if fpertask < 1:
@@ -242,6 +244,7 @@ class ORE_Submit(bpy.types.Operator):
 
 			block.setCommand(cmd)
 			block.setNumeric(fstart, fend, fpertask, finc)
+			block.setSequential(sequential)
 			job.blocks.append(block)
 
 		# Set job running parameters:


### PR DESCRIPTION
As far as I can tell, it works as it should. There is just one small issue: where to place the option in the Afanasy panel in Blender. For now I've put it here:
![sequential](https://cloud.githubusercontent.com/assets/3788756/6572200/9b7d3436-c710-11e4-90da-652b1776b84e.jpg)
It's not ideal (if you look at what options should be grouped together), but for now I don't have a better solution.