### PR TITLE
Removed 'offending' periods in descriptions

### DIFF
--- a/plugins/blender/addons/cgru_tools/operators.py
+++ b/plugins/blender/addons/cgru_tools/operators.py
@@ -45,7 +45,7 @@ class CGRU_Browse(bpy.types.Operator):
 
 
 class CGRU_Submit(bpy.types.Operator):
-	"""Submit job to Afanasy Renderfarm."""
+	"""Submit job to Afanasy Renderfarm"""
 
 	bl_idname = "cgru.submit"
 	bl_label = "Submit Job"

--- a/plugins/blender/addons/cgru_tools/properties.py
+++ b/plugins/blender/addons/cgru_tools/properties.py
@@ -13,22 +13,22 @@ from . import utils
 class CGRUProperties(bpy.types.PropertyGroup):
 	# General:
 	jobname = StringProperty(name='Job Name',
-		description='Job Name. Scene name if empty.', maxlen=512, default='')
+		description='Job Name, scene name if empty', maxlen=512, default='')
 	fpertask = IntProperty(name='Per Task', description='Frames Per One Task',
 		min=1, default=1)
 	sequential = IntProperty(name='Sequential',
-		description='Solve task with this step at first.',
+		description='Solve task with this step at first',
 		default=1)
 	pause = BoolProperty(name='Start Job Paused',
-		description='Send job in offline state.', default=0)
+		description='Send job in offline state', default=0)
 	packLinkedObjects = BoolProperty(name='Pack Linked Objects',
 		description='Make Local All linked Groups and Objects', default=0)
 	relativePaths = BoolProperty(name='Relative Paths',
 		description='Set Relative Paths for all Textures and Objects', default=0)
 	packTextures = BoolProperty(name='Pack Textures',
-		description='Pack all Textures into the Blend File.', default=0)
+		description='Pack all Textures into the Blend File', default=0)
 	splitRenderLayers = BoolProperty(name='Split Render Layers',
-		description='Split Render layer in blocks. Warning: this option disable post-processing passes (compositing nor seqeuncer are execute).', default=0)
+		description='Split Render layer in blocks. Warning: this option disable post-processing passes (compositing nor seqeuncer are execute)', default=0)
 	previewPendingApproval = BoolProperty(name='Preview Pending Approval',default = False)
 
 	# Render Settings:
@@ -37,22 +37,22 @@ class CGRUProperties(bpy.types.PropertyGroup):
 
 	# Paramerets:
 	priority = IntProperty(name='Priority',
-		description='Job order in user jobs list.', min=-1,
+		description='Job order in user jobs list', min=-1,
 		max=250, default=-1)
 	maxruntasks = IntProperty(name='Max Run Tasks',
-		description='Maximum number of running tasks.',
+		description='Maximum number of running tasks',
 		min=-1, max=9999, default=-1)
 	dependmask = StringProperty(name='Depend Mask',
-		description='Jobs to wait pattern.',
+		description='Jobs to wait pattern',
 		maxlen=512, default='')
 	dependmaskglobal = StringProperty(name='Global Depend',
-		description='All users jobs wait pattern.',
+		description='All users jobs wait pattern',
 		maxlen=512, default='')
 	hostsmask = StringProperty(name='Hosts Mask',
-		description='Hosts to run pattern.', maxlen=512,
+		description='Hosts to run pattern', maxlen=512,
 		default='')
 	hostsmaskexclude = StringProperty(name='Exclude Hosts',
-		description='Hosts to ignore pattern.',
+		description='Hosts to ignore pattern',
 		maxlen=512, default='')
 
 	adv_options = BoolProperty(name="More options", default=False)


### PR DESCRIPTION
Recently Blender started to spit out messages about 'offending' periods in descriptions of addons. This should get rid of it. It's not a real problem, but seems nicer this way.