### PR TITLE
Add clean logging macros

### DIFF
--- a/afanasy/src/libafanasy/logger.cpp
+++ b/afanasy/src/libafanasy/logger.cpp
@@ -1,0 +1,29 @@
+#include "logger.h"
+#include "../libafanasy/af.h"
+
+using namespace af;
+
+Logger::Logger(const char *func, const char *file, int line, const char *type)
+{
+    this->stream() << af::time2str() << ": " << type << " (" << func << "():" << Logger::shorterFilename(file) << ":" << line << ") ";
+}
+
+Logger::~Logger()
+{
+    std::string str = m_ss.str();
+    // trim extra newlines
+    while ( str.empty() == false && str[str.length() - 1] == '\n')
+        str.resize(str.length() - 1);
+    fprintf(stderr, "%s\n", str.c_str());
+    fflush(stderr);
+}
+
+const char * Logger::shorterFilename(const char *filename)
+{
+    const char *last_slash  = strrchr(filename, '/');
+    if ( last_slash == 0)
+        return filename;
+    while ( last_slash > filename && last_slash[-1] != '/')
+        --last_slash;
+    return last_slash;
+}

--- a/afanasy/src/libafanasy/logger.h
+++ b/afanasy/src/libafanasy/logger.h
@@ -1,0 +1,39 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <sstream>
+
+namespace af
+{
+
+/**
+ * @brief Class used in AF_LOG & co logging macros
+ * to automatically append timing, position in file, etc.
+ */
+class Logger
+{
+public:
+    Logger(const char *func, const char *file, int line, const char *type = "INFO");
+    ~Logger();
+
+    inline std::ostream &stream() { return m_ss; }
+
+private:
+    /**
+     * Reduces /a/b/c/d/e/f.foo into e/f.foo
+     * TODO: handle filesystems where separator is not a slash (like, a backslash)
+     */
+    static const char * shorterFilename(const char *filename);
+
+private:
+    std::ostringstream m_ss;
+};
+
+#define AF_DEBUG af::Logger(__func__, __FILE__, __LINE__, "DEBUG").stream()
+#define AF_LOG   af::Logger(__func__, __FILE__, __LINE__, "INFO").stream()
+#define AF_WARN  af::Logger(__func__, __FILE__, __LINE__, "WARNING").stream()
+#define AF_ERR   af::Logger(__func__, __FILE__, __LINE__, "ERROR").stream()
+
+} // namespace af
+
+#endif // LOGGER_H


### PR DESCRIPTION
@timurhai We spent quite some time fighting with the logs, and to be honest that was not a piece of cake... So may I suggest this very simple and convenient way to log?

Use it as follow:

    AF_LOG << "foo = " << foo << " :)";

And it will output:

    Fri 04 Mar 16:00.50: INFO (foobar():server/foobar.cpp:47): foo = 42 :)

It is automatically flushed and function, filename and lines are found
automatically as well.

As you may see in the code, other macros are available (`AF_WARN`, `AF_ERR`, etc.) and it is easy to extend.

Note that this is largely inspired from Kaldi's logging macros:
https://github.com/kaldi-asr/kaldi/blob/master/src/base/kaldi-error.cc

But licences don't conflict and I guess they found it somewhere since this pattern is quite common.