### PR TITLE
Security fix: buffer allocation rate limit

### DIFF
--- a/afanasy/src/libafanasy/msg.cpp
+++ b/afanasy/src/libafanasy/msg.cpp
@@ -99,7 +99,7 @@ void Msg::construct()
 bool Msg::allocateBuffer( int i_size, int i_copy_len, int i_copy_offset)
 {
 	if( m_type == Msg::TInvalid) return false;
-	if( i_size > Msg::SizeBufferLimit)
+    if( i_size < 0 || i_size > Msg::SizeBufferLimit)
 	{
 		AFERRAR("Msg::allocateBuffer: size > Msg::SizeBufferLimit ( %d > %d)", i_size, Msg::SizeBufferLimit)
 		setInvalid();

--- a/afanasy/src/libafanasy/name_afjson.cpp
+++ b/afanasy/src/libafanasy/name_afjson.cpp
@@ -26,6 +26,13 @@ char * af::jsonParseMsg( rapidjson::Document & o_doc, const af::Msg * i_msg, std
 
 char * af::jsonParseData( rapidjson::Document & o_doc, const char * i_data, int i_data_len, std::string * o_err)
 {
+    if( i_data_len < 0 || i_data_len > Msg::SizeBufferLimit)
+    {
+        if( o_err )
+            *o_err = "Invalid buffer size";
+        AFERRAR("jsonParseData: size > Msg::SizeBufferLimit ( %d > %d)", i_data_len, Msg::SizeBufferLimit);
+        return NULL;
+    }
 	char * data = new char[i_data_len+1];
 	memcpy( data, i_data, i_data_len);
 	data[i_data_len] = '\0';


### PR DESCRIPTION
Prevent server from allocating too much memory for JSON messages.
There was already such rate limit in Msg::allocateBuffer but not for JSON.

exploit:

```
$ telnet <afserver address> 51000
AFANASY 999999999999999 JSON {"                                ":0}
```

That's it! It actually makes the server allocate a negative number of
bytes because the big 999... number overflows the maximum int.