### PR TITLE
Fix regression issue when loading non numeric block from store

### DIFF
--- a/afanasy/src/libafanasy/blockdata.cpp
+++ b/afanasy/src/libafanasy/blockdata.cpp
@@ -187,7 +187,7 @@ void BlockData::jsonRead( const JSON & i_object, std::string * io_changes)
 
 	jsonReadTasks( i_object);
 	// If tasks are not preset in json data, condider that block is numeric at first
-	bool numeric = ( m_tasks_data == NULL );
+	bool numeric = ( m_flags & FNumeric );
 
 	// But on store reading, tasks are read later from separate file
 //	if( numeric ) jr_bool("numeric", numeric, i_object);


### PR DESCRIPTION
When refactoring to move the `numeric` field of block data into one of the flags
this must have been forgot.

See [comments of 7c4b518](https://github.com/CGRU/cgru/commit/7c4b518605678dcfb9cde1877764adab40a44ce3#commitcomment-17271562)