### PR TITLE
Enable or Disable services by regexp

### DIFF
--- a/afanasy/src/server/renderaf.cpp
+++ b/afanasy/src/server/renderaf.cpp
@@ -4,6 +4,7 @@
 #include "../libafanasy/msg.h"
 #include "../libafanasy/msgqueue.h"
 #include "../libafanasy/farm.h"
+#include "../libafanasy/regexp.h"
 
 #include "action.h"
 #include "afcommon.h"
@@ -351,10 +352,15 @@ void RenderAf::v_action( Action & i_action)
 			wolWake( i_action.monitors);
 		else if( type == "service")
 		{
-			std::string name; bool enable;
-			af::jr_string("name", name, operation);
+			af::RegExp service_mask; bool enable;
+			af::jr_regexp("name", service_mask, operation);
 			af::jr_bool("enable", enable, operation);
-			setService( name, enable);
+			for (int i = 0 ; i < m_host.getServicesNum() ; ++i)
+			{
+				std::string service = m_host.getServiceName(i);
+				if( service_mask.match( service))
+					setService( service, enable);
+			}
 		}
 		else if( type == "restore_defaults")
 		{

--- a/afanasy/src/watch/listrenders.cpp
+++ b/afanasy/src/watch/listrenders.cpp
@@ -520,12 +520,19 @@ void ListRenders::setService( bool enable)
 	if( enable ) caption = "Enable " + caption; else caption = "Disable " + caption;
 
 	bool ok;
-	QString service = QInputDialog::getText(this, caption, "Enter Service Name", QLineEdit::Normal, QString(), &ok);
+	QString service_mask = QInputDialog::getText(this, caption, "Enter Service Name", QLineEdit::Normal, QString(), &ok);
 	if( !ok) return;
-
+	
+	QRegExp rx( service_mask, Qt::CaseInsensitive);
+	if( rx.isValid() == false )
+	{
+		displayError( rx.errorString());
+		return;
+	}
+	
 	std::ostringstream str;
 	af::jsonActionOperationStart( str, "renders", "service", "", getSelectedIds());
-	str << ",\n\"name\":\"" << afqt::qtos( service) << "\"";
+	str << ",\n\"name\":\"" << afqt::qtos( service_mask) << "\"";
 	str << ",\n\"enable\":" << ( enable ? "true": "false" );
 	af::jsonActionOperationFinish( str);
 	Watch::sendMsg( af::jsonMsg( str));


### PR DESCRIPTION
Before one had to do one by one.
For instance:

 * To disable/enable all, type `.*`
 * To disable/enable services `lorem` and `ipsum`, type `lorem|ipsum`