### PR TITLE
Assign a clearer notion of ownership on the TaskExec pointers

### DIFF
--- a/afanasy/src/libafanasy/render.cpp
+++ b/afanasy/src/libafanasy/render.cpp
@@ -54,6 +54,9 @@ void Render::construct()
 
 Render::~Render()
 {
+	std::list<af::TaskExec*>::iterator it;
+	for( it = m_tasks.begin(); it != m_tasks.end(); it++)
+		delete *it;
 }
 
 void Render::v_jsonWrite( std::ostringstream & o_str, int i_type) const // Thread-safe
@@ -298,6 +301,13 @@ int Render::v_calcWeight() const
    weight += sizeof(Render) - sizeof( Client);
    for( std::list<TaskExec*>::const_iterator it = m_tasks.begin(); it != m_tasks.end(); it++) weight += (*it)->calcWeight();
    return weight;
+}
+
+std::list<TaskExec *> Render::takeTasks()
+{
+	std::list<af::TaskExec*> l = m_tasks;
+	m_tasks.clear();
+	return l;
 }
 
 void Render::v_generateInfoStream( std::ostringstream & stream, bool full) const

--- a/afanasy/src/libafanasy/render.h
+++ b/afanasy/src/libafanasy/render.h
@@ -90,8 +90,9 @@ public:
    virtual int v_calcWeight() const; ///< Calculate and return memory size.
 
    inline long long getTasksStartFinishTime() const { return m_task_start_finish_time; }///< Get tasks start or finish time.
-   inline const std::list<TaskExec*> & getTasks() { return m_tasks;}
-   inline int getTasksNumber() const { return int(m_tasks.size());}
+	/// Take ownership of the task execs of the render
+	std::list<af::TaskExec*> takeTasks();
+	inline int getTasksNumber() const { return int(m_tasks.size());}
 
    virtual void v_jsonWrite( std::ostringstream & o_str, int type) const;
 

--- a/afanasy/src/server/block.cpp
+++ b/afanasy/src/server/block.cpp
@@ -208,10 +208,10 @@ bool Block::v_startTask( af::TaskExec * taskexec, RenderAf * render, MonitorCont
    return true;
 }
 
-void Block::reconnectTask( af::TaskExec & i_taskexec, RenderAf & i_render, MonitorContainer * i_monitoring)
+void Block::reconnectTask(af::TaskExec *i_taskexec, RenderAf & i_render, MonitorContainer * i_monitoring)
 {
-	Task * task = m_tasks[i_taskexec.getTaskNum()];
-	task->reconnect( &i_taskexec, m_data->getRunningTasksCounter(), &i_render, i_monitoring);
+	Task * task = m_tasks[i_taskexec->getTaskNum()];
+	task->reconnect( i_taskexec, m_data->getRunningTasksCounter(), &i_render, i_monitoring);
 }
 
 

--- a/afanasy/src/server/block.h
+++ b/afanasy/src/server/block.h
@@ -49,7 +49,8 @@ public:
 	/// Records that a task execution is being performed by a given running
 	/// render. This is used when restarting the server without restarting the
 	/// renders.
-	void reconnectTask( af::TaskExec & i_taskexec, RenderAf & i_render, MonitorContainer * i_monitoring);
+	/// This method taks the ownership of `i_taskexec`
+	void reconnectTask( af::TaskExec * i_taskexec, RenderAf & i_render, MonitorContainer * i_monitoring);
 
 	void taskFinished( af::TaskExec * taskexec, RenderAf * render, MonitorContainer * monitoring);
 

--- a/afanasy/src/server/jobaf.cpp
+++ b/afanasy/src/server/jobaf.cpp
@@ -961,10 +961,10 @@ void JobAf::v_updateTaskState( const af::MCTaskUp& taskup, RenderContainer * ren
 	}
 }
 
-void JobAf::reconnectTask(af::TaskExec & i_taskexec, RenderAf & i_render, MonitorContainer * i_monitoring)
+void JobAf::reconnectTask(af::TaskExec *i_taskexec, RenderAf & i_render, MonitorContainer * i_monitoring)
 {
-	int b = i_taskexec.getBlockNum();
-	int t = i_taskexec.getTaskNum();
+	int b = i_taskexec->getBlockNum();
+	int t = i_taskexec->getTaskNum();
 	if( false == checkBlockTaskNumbers( b, t, "reconnectTask")) return;
 	m_blocks[b]->reconnectTask( i_taskexec, i_render, i_monitoring);
 }

--- a/afanasy/src/server/jobaf.h
+++ b/afanasy/src/server/jobaf.h
@@ -74,7 +74,8 @@ public:
     virtual void v_updateTaskState( const af::MCTaskUp & taskup, RenderContainer * renders, MonitorContainer * monitoring);
      
 /// Reconnect running task
-    void reconnectTask( af::TaskExec & i_taskexec, RenderAf & i_render, MonitorContainer * i_monitoring);
+/// This method taks the ownership of `i_taskexec`
+    void reconnectTask( af::TaskExec * i_taskexec, RenderAf & i_render, MonitorContainer * i_monitoring);
 
 /// Send tasks output to a specified address.
 	void listenOutput( RenderContainer * i_renders, bool i_subscribe, int i_block, int i_task);

--- a/afanasy/src/server/jobcontainer.cpp
+++ b/afanasy/src/server/jobcontainer.cpp
@@ -54,17 +54,17 @@ void JobContainer::updateTaskState( af::MCTaskUp &taskup, RenderContainer * rend
             if( taskup.getStatus() == af::TaskExec::UPPercent) RenderAf::closeLostTask( taskup);
 }
 
-void JobContainer::reconnectTask( af::TaskExec & i_taskexec, RenderAf & i_render, MonitorContainer * i_monitoring)
+void JobContainer::reconnectTask( af::TaskExec * i_taskexec, RenderAf & i_render, MonitorContainer * i_monitoring)
 {
 	#ifdef AFOUTPUT
 	AF_DEBUG << "Reconnecting task " << i_taskexec << " with " << i_render;
 	#endif
 
     JobContainerIt jobsIt( this);
-	JobAf* job = jobsIt.getJob( i_taskexec.getJobId());
+	JobAf* job = jobsIt.getJob( i_taskexec->getJobId());
     if( NULL == job )
     {
-		AF_ERR << "Job with id=" << i_taskexec.getJobId() << " does not exists.";
+		AF_ERR << "Job with id=" << i_taskexec->getJobId() << " does not exists.";
         return;
     }
 

--- a/afanasy/src/server/jobcontainer.h
+++ b/afanasy/src/server/jobcontainer.h
@@ -28,13 +28,14 @@ public:
 	void updateTaskState( af::MCTaskUp &taskup, RenderContainer * renders, MonitorContainer * monitoring);
 	
 	/**
-	 * @brief Reconnect a running task to the server
+	 * @brief Reconnect a running task to the server.
+	 * This method taks the ownership of `i_taskexec`
 	 * @param taskexec: TaskExec to consider as running
 	 * @param running_render: Render claiming to be running this task
 	 * @param renders: renders pool
 	 * @param monitoring: monitors pool
 	 */
-	void reconnectTask(af::TaskExec & i_taskexec, RenderAf & i_render, MonitorContainer * i_monitoring);
+	void reconnectTask(af::TaskExec * i_taskexec, RenderAf & i_render, MonitorContainer * i_monitoring);
 
 	void getWeight( af::MCJobsWeight & jobsWeight );
 	

--- a/afanasy/src/server/renderaf.cpp
+++ b/afanasy/src/server/renderaf.cpp
@@ -190,8 +190,12 @@ bool RenderAf::online( RenderAf * render, JobContainer * i_jobs, MonitorContaine
 	std::list<af::TaskExec*>::iterator it;
 	for( it = render->m_tasks.begin() ; it != render->m_tasks.end() ; ++it)
 	{
-		i_jobs->reconnectTask( **it, *this, monitoring);
+		i_jobs->reconnectTask( *it, *this, monitoring);
 	}
+	// Job::reconnectTask took the ownership of the taskexecs, so we prevent
+	// them from being cleaned by render's dtor:
+	render->m_tasks.clear();
+	
 
 
 	std::string str = "Online '" + m_engine + "'.";
@@ -580,7 +584,6 @@ void RenderAf::removeTask( const af::TaskExec * taskexec)
 		if( *it == taskexec)
 		{
 			it = m_tasks.erase( it);
-			continue;
 		}
 	}
 
@@ -997,12 +1000,6 @@ void RenderAf::closeLostTask( const af::MCTaskUp &taskup)
 	AFCommon::QueueLogError( stream.str());
 
 	render->m_re.addTaskClose( taskup);
-}
-
-void RenderAf::deleteTaskExecs()
-{
-	for( std::list<af::TaskExec*>::iterator it = m_tasks.begin(); it != m_tasks.end(); it++)
-		delete *it;
 }
 
 af::Msg * RenderAf::writeFullInfo( bool i_binary) const

--- a/afanasy/src/server/renderaf.h
+++ b/afanasy/src/server/renderaf.h
@@ -33,6 +33,7 @@ public:
 	bool online( RenderAf * render, JobContainer * i_jobs, MonitorContainer * monitoring);
 
 /// Add task \c taskexec to render, \c start or only capture it
+/// Takes over the taskexec ownership
 	void setTask( af::TaskExec *taskexec, MonitorContainer * monitoring, bool start = true);
 
 /// Start tast \c taskexec on remote render host, task must be set before and exists on render.
@@ -50,6 +51,7 @@ public:
 		{ stopTask(taskup.getNumJob(), taskup.getNumBlock(), taskup.getNumTask(), taskup.getNumber());}
 
 /// Make Render to finish task.
+/// Releases the ownership of taskexec (Render will not own it any more)
 	void taskFinished( const af::TaskExec * taskexec, MonitorContainer * monitoring);
 
 /// Refresh parameters.

--- a/afanasy/src/server/renderaf.h
+++ b/afanasy/src/server/renderaf.h
@@ -89,10 +89,6 @@ public:
 	inline void listenTask( const af::MCTaskPos & i_tp, bool i_subscribe)
 		{ if( i_subscribe) m_re.taskListenAdd( i_tp); else m_re.taskListenRem( i_tp); }
 
-	/// Delete tasks executables.
-	/// Needed for server to free mem of a reconnecting render.
-	void deleteTaskExecs();
-
 public:
 	/// Set container:
 	inline static void setRenderContainer( RenderContainer * i_container){ ms_renders = i_container;}
@@ -103,7 +99,11 @@ public:
 private:
 	void initDefaultValues();
 
+	/// Add the task exec to this render and take over its ownership (meaning
+	/// one should not free taskexec after having provided it to this method).
 	void addTask( af::TaskExec * taskexec);
+	/// Remove the task exec from this render and give back its ownership to the
+	/// caller.
 	void removeTask( const af::TaskExec * taskexec);
 
 	void addService( const std::string & type);

--- a/afanasy/src/server/rendercontainer.cpp
+++ b/afanasy/src/server/rendercontainer.cpp
@@ -42,7 +42,6 @@ af::Msg * RenderContainer::addRender( RenderAf *newRender, JobContainer * i_jobs
                errLog += "\nExisting render:\n";
                errLog += render->v_generateInfoString( false);
                AFCommon::QueueLogError( errLog);
-			   newRender->deleteTaskExecs();
                delete newRender;
                // Return -1 ID to render to tell that there is already registered render with the same name:
                return new af::Msg( af::Msg::TRenderId, -1);
@@ -71,7 +70,6 @@ af::Msg * RenderContainer::addRender( RenderAf *newRender, JobContainer * i_jobs
 		}
 		else
 		{
-			newRender->deleteTaskExecs();
 			delete newRender;
 		}
 
@@ -87,7 +85,6 @@ af::Msg * RenderContainer::addRender( RenderAf *newRender, JobContainer * i_jobs
 	}
 	else
 	{
-		newRender->deleteTaskExecs();
 		delete newRender;
 	}
 

--- a/afanasy/src/server/task.h
+++ b/afanasy/src/server/task.h
@@ -26,6 +26,8 @@ public:
 
 	virtual void v_start( af::TaskExec * taskexec, int * runningtaskscounter, RenderAf * render, MonitorContainer * monitoring);
 
+	/// Reconnect Task to an existing TaskExec
+	/// This method taks the ownership of `i_taskexec`
 	void reconnect( af::TaskExec * i_taskexec, int * o_runningtaskscounter, RenderAf * i_render, MonitorContainer * i_monitoring);
 
 /// Update task state.

--- a/afanasy/src/server/taskrun.cpp
+++ b/afanasy/src/server/taskrun.cpp
@@ -230,6 +230,7 @@ void TaskRun::update( const af::MCTaskUp& taskup, RenderContainer * renders, Mon
 
 bool TaskRun::refresh( time_t currentTime, RenderContainer * renders, MonitorContainer * monitoring, int & errorHostId)
 {
+	if( m_zombie ) return false;
 	
 	if( m_exec == NULL)
 	{
@@ -239,7 +240,6 @@ bool TaskRun::refresh( time_t currentTime, RenderContainer * renders, MonitorCon
 		return false;
 	}
 	//printf("TaskRun::refresh: %s[%d][%d]\n", block->job->getName().toUtf8().data(), block->data->getBlockNum(), tasknum);
-	if( m_zombie ) return false;
 	bool changed = false;
 
 	// Max running time check:
@@ -323,6 +323,8 @@ void TaskRun::finish( const std::string & message, RenderContainer * renders, Mo
          m_block->taskFinished( m_exec, render, monitoring);
       }
 		AFCommon::DBAddTask( m_exec, m_progress, m_block->m_job, render);
+		delete m_exec;
+		m_exec = NULL;
    }
 
    m_task->v_monitor( monitoring );

--- a/afanasy/src/server/taskrunmulti.cpp
+++ b/afanasy/src/server/taskrunmulti.cpp
@@ -117,6 +117,7 @@ void TaskRunMulti::addHost( af::TaskExec * taskexec, RenderAf * render, MonitorC
 
 void TaskRunMulti::setMasterTask()
 {
+	if( isZombie()) return;
 	m_exec = m_execs.front();
 	m_hostId = m_hostids.front();
 	m_execs.pop_front();

--- a/afanasy/src/watch/itemrender.cpp
+++ b/afanasy/src/watch/itemrender.cpp
@@ -219,7 +219,7 @@ void ItemRender::updateValues( af::Node *node, int type)
 		deleteTasks();
 	        m_tasksusers.clear();
 	    m_tasks_users_counts.clear();
-	    m_tasks = render->getTasks();
+	    m_tasks = render->takeTasks();
 		QStringList tasks_users;
 		QList<int> tasks_counts;
 	    for( std::list<af::TaskExec*>::const_iterator it = m_tasks.begin(); it != m_tasks.end(); it++)


### PR DESCRIPTION
Unless specified, the Render object owns its TaskExecs contained in m_tasks.

All methods modifying this ownership by either giving it up or taking over a
new task are commented in their docstring.

There should now be no memory leak of TaskExecs any more (not related to this at least).

Implement the point 2) given in [this comment](https://github.com/CGRU/cgru/commit/b377fc3b2ae981920ecb812ef181a2ef104d3325#commitcomment-17643608)

@timurhai This is an alternative to 99e38ca. Contrary to [what you feared](https://github.com/CGRU/cgru/commit/eb581d37aa240cbffaba039702ea497f958e900f#commitcomment-17644603), this does not introduce much more code. And also note that it does not make any extra memory allocation. If you like it, I suggest that we remove the `bool` return value you just added since it should not be needed any more. Unless you have other ideas of use for it in the furure.