### PR TITLE
Resolve bug #265 and introduce pixelcrop

### DIFF
--- a/afanasy/src/server/jobaf.cpp
+++ b/afanasy/src/server/jobaf.cpp
@@ -264,7 +264,7 @@ bool JobAf::initialize()
 			{
 				taskstate = AFJOB::STATE_READY_MASK;
 			}
-			else if( taskstate & AFJOB::STATE_RUNNING_MASK )
+			else if( taskstate & AFJOB::STATE_RUNNING_MASK && ( false == m_blocks_data[b]->isMultiHost()))
 			{
 				taskstate = taskstate | AFJOB::STATE_WAITRECONNECT_MASK;
 				taskstate = taskstate & (~AFJOB::STATE_RUNNING_MASK );


### PR DESCRIPTION
This commit resolve the bug #265 and introduce a crop with pixelcrop, a crop with pixel values.
image:pixelcrop property exists at least since H12.0.