### PR TITLE
parser fixes and improvements, pep8

### DIFF
--- a/afanasy/python/parsers/mantra.py
+++ b/afanasy/python/parsers/mantra.py
@@ -7,8 +7,7 @@ import re
 PERCENT = 'ALF_PROGRESS '
 PERCENT_len = len(PERCENT)
 
-IMAGE = 'Generating Image:'
-IMAGE_len = len(IMAGE)
+IMAGE_RE = re.compile(r'.*Generating Image: (.+) \(\d+x\d+\)')
 
 ErrorsRE = [re.compile(r'Error loading geometry .* from stdin')]
 
@@ -19,7 +18,11 @@ class mantra(parser.parser):
 
     def __init__(self):
         parser.parser.__init__(self)
-        self.str_warning = ['Unable to access file', 'Unable to load texture']
+        self.str_warning = ['Unable to access file', 'Unable to load texture',
+                            'Recompress failed', 'WARNING: A procedural of',
+                            ' Unknown parameter: ', ' is rendering as a packed '
+                            'procedural but has a mix of packed and '
+                            'non-packed primitives']
         self.str_error = [
             'No licenses could be found to run this application',
             'Please check for a valid license server host',
@@ -40,10 +43,9 @@ class mantra(parser.parser):
 
         lines = data.split('\n')
         for line in lines:
-            if line.find(IMAGE) != -1:
-                line = line[IMAGE_len:]
-                line = line[:line.find('(')]
-                self.appendFile(line.strip())
+            m = IMAGE_RE.match(line)
+            if m:
+                self.appendFile(m.group(1))
 
         percent_pos = data.find(PERCENT)
         if percent_pos > -1:

--- a/afanasy/python/parsers/parser.py
+++ b/afanasy/python/parsers/parser.py
@@ -12,10 +12,10 @@ class parser(object):
     """
 
     def __init__(self):
-        self.str_warning = ['warning']  # '[ PARSER WARNING ]'
-        self.str_error = ['error']      # '[ PARSER ERROR ]'
-        self.str_badresult = []         # '[ PARSER BAD RESULT ]'
-        self.str_finishedsuccess = []   # '[ PARSER FINISHED SUCCESS ]'
+        self.str_warning = ['warning']
+        self.str_error = ['error']
+        self.str_badresult = []
+        self.str_finishedsuccess = []
         self.percent = 0
         self.frame = 0
         self.percentframe = 0
@@ -27,6 +27,8 @@ class parser(object):
         self.report = ''
         self.result = None
         self.log = None
+        self.numframes = 0
+        self.taskInfo = {}
 
         self.files = []
         self.files_onthefly = []
@@ -174,35 +176,33 @@ class parser(object):
         if self.percent > 100:
             self.percent = 100
 
-
-    def toHTML( self, i_data):
+    def toHTML(self, i_data):
         """ Convert data to HTML.
             Designed for GUIs for escape sequences, errors highlighting.
         :param i_data: input data
         :return: converted data
         """
-        lines = i_data.replace('\r','').split('\n')
+        lines = i_data.replace('\r', '').split('\n')
         html = []
 
         for line in lines:
-            html.append( self.toHTMLline(line))
+            html.append(self.toHTMLline(line))
+        return '<br>\n'.join(html)
 
-        return '<br>\n'.join( html)
-
-    def toHTMLline( self, i_line):
+    def toHTMLline(self, i_line):
         """ Convert line to HTML.
             Designed for GUIs for escape sequences, errors highlighting.
         :param i_line: input line
         :return: converted line
         """
-        self.parse( i_line,'html')
+        self.parse(i_line, 'html')
 
         if self.error:
             i_line = '<span style="background-color:#FF0000"><b>' + i_line + '</b></span>'
         if self.badresult:
             i_line = '<span style="background-color:#FF00FF"><b>' + i_line + '</b></span>'
         if self.warning:
-            i_line = '<span style="background-color:#FFFF00"><b>' + i_line + '</b></span>'
+            i_line = '<span style="background-color:#FFA500"><b>' + i_line + '</b></span>'
         if self.finishedsuccess:
             i_line = '<span style="color:#008800"><b>' + i_line + '</b></span>'
         if len(self.activity):
@@ -210,9 +210,9 @@ class parser(object):
         if len(self.report):
             i_line = '<i><b>' + i_line + '</b></i>'
 
-        return self.tagHTML( i_line)
+        return self.tagHTML(i_line)
 
-    def tagHTML( self, i_line):
+    def tagHTML(self, i_line):
         """ Convert line to HTML.
             Designed for GUIs for escape sequences, errors highlighting.
             Function designed to be implemented in child classes, if special highlinghting needed.

--- a/plugins/houdini/afanasy.py
+++ b/plugins/houdini/afanasy.py
@@ -87,7 +87,6 @@ class BlockParameters:
             self.depend_mask_global = str(
                 afnode.parm('depend_mask_global').eval())
 
-
         # Process frame range:
         opname = afnode.path()
         if afnode.parm('trange').eval() > 1:
@@ -274,7 +273,7 @@ class BlockParameters:
 
         block = af.Block(self.name, self.type)
         block.setParser(self.parser)
-        block.setCommand( cmd, self.cmd_useprefix)
+        block.setCommand(cmd, self.cmd_useprefix)
         if self.preview != '':
             block.setFiles([self.preview])
 
@@ -587,29 +586,27 @@ def getBlockParameters(afnode, ropnode, subblock, prefix, frame_range):
             params.append(block_generate)
 
     elif len(str(afnode.parm('ds_node').eval())):
-    # Case distribute simulation:
-        ds_node_path = str( afnode.parm('ds_node').eval())
-        ds_node = hou.node( ds_node_path)
+        # Case distribute simulation:
+        ds_node_path = str(afnode.parm('ds_node').eval())
+        ds_node = hou.node(ds_node_path)
         if not ds_node:
             hou.ui.displayMessage('No such control node: "%s"' % ds_node_path)
             return
-        parms = ['address','port','slice']
+        parms = ['address', 'port', 'slice']
         for parm in parms:
-            if not ds_node.parm( parm):
+            if not ds_node.parm(parm):
                 hou.ui.displayMessage('Control node "%s" does not have "%s" parameter' % (ds_node_path, parm))
                 return
-        ds_num_slices = int( afnode.parm('ds_num_slices').eval())
-        for s in range( 0, ds_num_slices):
-            par = BlockParameters( afnode, ropnode, subblock, prefix, frame_range)
+        ds_num_slices = int(afnode.parm('ds_num_slices').eval())
+        for s in range(0, ds_num_slices):
+            par = BlockParameters(afnode, ropnode, subblock, prefix, frame_range)
             par.name += '-s%d' % s
             par.frame_pertask = par.frame_last - par.frame_first + 1
             par.auxargs = ' --ds_node "%s"' % ds_node_path
             par.auxargs += ' --ds_address "%s"' % str(afnode.parm('ds_address').eval())
             par.auxargs += ' --ds_port %d' % int(afnode.parm('ds_port').eval())
             par.auxargs += ' --ds_slice %d' % s
-            params.append( par)
-
-
+            params.append(par)
     else:
         params.append(
             BlockParameters(afnode, ropnode, subblock, prefix, frame_range)
@@ -651,7 +648,7 @@ def getJobParameters(afnode, subblock=False, frame_range=None, prefix=''):
     if output_driver_path:
         output_driver = hou.node(output_driver_path)
         if output_driver:
-            nodes.insert( 0, output_driver)
+            nodes.insert(0, output_driver)
         else:
             hou.ui.displayMessage('Can`t find output drive node: "%s"' % output_driver_path)
 


### PR DESCRIPTION
parsers/mantra.py:
- "Image" parsing failed when running mantra with "-V", because then a
timestamp is prepended to the "Generating Image" line, causing the
"find" not to work any more
- add additional warning strings

parsers/parser.py
- pep8
- the warning color of "toHTMLline" is much too bright for the dark
afwatch theme and the line's text is not readable any more, changed to a
mid-orange

houdini/afanasy.py
- pep8, whitespace