### PR TITLE
Update blender.py

### DIFF
--- a/afanasy/python/parsers/blender.py
+++ b/afanasy/python/parsers/blender.py
@@ -16,7 +16,8 @@ class blender(parser.parser):
 		parser.parser.__init__(self)
 		self.str_error = [
 			"Warning: Unable to open",
-			"Render error: cannot save"]
+			"Render error: cannot save",
+			"Error: CUDA error"]
 		self.firstframe = True
 		self.framestring = keyframe
 


### PR DESCRIPTION
Hi Timur,

Just add an error in the blender.py parser to handle GPU errors in Blender Cycles render engine.
In the current behavior, Afanasy considers the task done and Blender leave an image with errors (usually a mix of renderer and unrendered parts).


