### PR TITLE
Added aliases to afwatch preview commands

### DIFF
--- a/afanasy/src/libafanasy/environment.h
+++ b/afanasy/src/libafanasy/environment.h
@@ -257,8 +257,8 @@ private:
 	static bool perm_user_mod_his_priority;
 	static bool perm_user_mod_job_priority;
 
-	static std::vector<std::string> previewcmds;      ///< Preview commannds, separated by AFWATCH::CMDS_SEPARATOR
-	static std::vector<std::string> rendercmds;       ///< Render commannds, separated by AFWATCH::CMDS_SEPARATOR
+	static std::vector<std::string> previewcmds;      ///< Preview commannds
+	static std::vector<std::string> rendercmds;       ///< Render commannds
 	static std::vector<std::string> rendercmds_admin; ///< Render commannds for admin only
 	static int watch_get_events_sec;
 	static int watch_refresh_gui_sec;

--- a/afanasy/src/watch/listtasks.cpp
+++ b/afanasy/src/watch/listtasks.cpp
@@ -247,7 +247,6 @@ void ListTasks::generateMenu(QMenu &o_menu, Item *item)
 				o_menu.addAction( action);
 
 				const std::vector<std::string> preview_cmds = af::Environment::getPreviewCmds();
-
 				if( preview_cmds.size())
 				{
 					QMenu * submenu_cmd = new QMenu( "Preview", this);
@@ -260,8 +259,9 @@ void ListTasks::generateMenu(QMenu &o_menu, Item *item)
                             for( int p = 0; p < preview_cmds.size(); p++)
                             {
                                 QString cmd = afqt::stoq( preview_cmds[p]);
+                                QStringList cmdSplit = cmd.split("|");
                                 
-                                ActionIdId * actionid = new ActionIdId( p, i, QString(cmd).replace("@ARG@", afqt::stoq(files[i]).right(55)), this);
+                                ActionIdId * actionid = new ActionIdId( p, i, QString(cmdSplit.first()), this);
                                 connect( actionid, SIGNAL( triggeredId(int,int) ), this, SLOT( actTaskPreview(int,int) ));
                                 submenu_img->addAction( actionid);
                             }
@@ -273,8 +273,9 @@ void ListTasks::generateMenu(QMenu &o_menu, Item *item)
                         for( int p = 0; p < preview_cmds.size(); p++)
                         {
                             QString cmd = afqt::stoq( preview_cmds[p]);
+                            QStringList cmdSplit = cmd.split("|");
                             
-                            ActionIdId * actionid = new ActionIdId( p, 0, QString(cmd).replace("@ARG@", afqt::stoq(files[0]).right(55)), this);
+                            ActionIdId * actionid = new ActionIdId( p, 0, QString(cmdSplit.first()).replace("@ARG@", afqt::stoq(files[0]).right(55)), this);
                             connect( actionid, SIGNAL( triggeredId(int,int) ), this, SLOT( actTaskPreview(int,int) ));
                             submenu_cmd->addAction( actionid);
                         }
@@ -782,8 +783,9 @@ void ListTasks::actTaskPreview( int num_cmd, int num_img)
 
 	QString cmd( afqt::stoq( af::Environment::getPreviewCmds()[num_cmd]));
 	cmd = cmd.replace( AFWATCH::CMDS_ARGUMENT, arg);
+	QStringList cmdSplit = cmd.split("|");
 
-	Watch::startProcess( cmd, wdir);
+	Watch::startProcess( cmdSplit.last(), wdir);
 }
 
 void ListTasks::actBlockPreview( int num_cmd, int num_img)
@@ -821,8 +823,9 @@ void ListTasks::actBlockPreview( int num_cmd, int num_img)
 
     QString cmd( afqt::stoq( af::Environment::getPreviewCmds()[num_cmd]));
     cmd = cmd.replace( AFWATCH::CMDS_ARGUMENT, arg);
+    QStringList cmdSplit = cmd.split("|");
 
-    Watch::startProcess( cmd, wdir);
+    Watch::startProcess( cmdSplit.last(), wdir);
 }
 
 void ListTasks::blockAction( int id_block, QString i_action) { blockAction( id_block, i_action, true); }

--- a/afanasy/src/watch/watch.cpp
+++ b/afanasy/src/watch/watch.cpp
@@ -41,9 +41,6 @@ QLinkedList<int>       Watch::ms_listenjobids;
 QLinkedList<int>       Watch::ms_watchtasksjobids;
 QLinkedList<QWidget*>  Watch::ms_watchtaskswindows;
 
-QStringList Watch::ms_previewcmds;
-QStringList Watch::ms_rendercmds;
-
 QMap<QString, QPixmap *> Watch::ms_services_icons_large;
 QMap<QString, QPixmap *> Watch::ms_services_icons_small;
 

--- a/afanasy/src/watch/watch.h
+++ b/afanasy/src/watch/watch.h
@@ -127,9 +127,6 @@ private:
 	static QLinkedList<Wnd*> ms_windows;
 	static QLinkedList<Receiver*> ms_receivers;
 
-	static QStringList ms_previewcmds;
-	static QStringList ms_rendercmds;
-
 	static QLinkedList<int> ms_listenjobids;
 	static QLinkedList<int> ms_watchtasksjobids;
 	static QLinkedList<QWidget*> ms_watchtaskswindows;


### PR DESCRIPTION
I've added preview commands using a single "|" character to split between alias and command. It should not break with any previous configs (unless "|" is used in the command).

Here are some examples on how it looks :
Single file sequence -
http://imgur.com/a/68hPW

Multiple sequences -
http://imgur.com/a/Hvdf5

And here is an example of how it's defined in config.json :
"avplay|avplay \"@ARG@\""
