### PR TITLE
Fixes for ``afjob.py`` and ``maya.afanasy``

### DIFF
--- a/afanasy/python/afjob.py
+++ b/afanasy/python/afjob.py
@@ -577,7 +577,7 @@ if __name__ == '__main__':
         cmd += ' -V a -f "%s"' % scene
 
     # Maya (3Delight and Mental Ray):
-    elif (ext == 'mb') or (ext == 'ma'):
+    elif ext in ['ma', 'mb']:
         if blocktype == 'maya_mental':
             scenetype = 'maya_mental'
         elif blocktype == 'maya_delight':
@@ -622,8 +622,14 @@ if __name__ == '__main__':
                 images = afcommon.patternFromPaths(images[0], images[1])
             else:
                 images = afcommon.patternFromFile(images[0])
-        if pwd != '':
-            cmd += ' -proj "%s"' % os.path.normpath(pwd)
+
+        if proj:
+            cmd += ' -proj "%s"' % os.path.normpath(proj)
+        else:
+            if pwd != '':
+                cmd += ' -proj "%s"' % os.path.normpath(pwd)
+            else:
+                cmd += ' -proj "%s"' % os.path.normpath(os.path.dirname(scene))
 
         if output != '':
             cmd += ' -rd "%s"' % os.path.normpath(output)
@@ -802,8 +808,8 @@ if __name__ == '__main__':
             cmd = 'fusion' + cmdextension
 
         cmd += ' "%s"' % scene
-        cmd += ' /render /start @#@ /end @#@ /step %d /quiet /quietlicense /clean /quit' % by
-        cmd += ' /log %TEMP%/fusion_render.log'
+        cmd += ' /render /start @#@ /end @#@ /step %d /quiet' % by
+        cmd += ' /quietlicense /clean /quit /log %TEMP%/fusion_render.log'
 
     # Clarisse:
     elif ext == 'render':

--- a/plugins/maya/afanasy/__init__.py
+++ b/plugins/maya/afanasy/__init__.py
@@ -305,7 +305,7 @@ class UI(object):
             '-hostsexcl %(exc)s',
             '-fpt %(fpt)s',
             '-name "%(name)s"',
-            '-pwd "%(pwd)s"',
+            # '-pwd "%(pwd)s"',
             '-proj "%(proj)s"',
             '-images "%(images)s"',
             '-deletescene'
@@ -320,7 +320,7 @@ class UI(object):
             'exc': hosts_exclude,
             'fpt': frames_per_task,
             'name': job_name,
-            'pwd': project_path,
+            # 'pwd': project_path,
             'proj': project_path,
             'images': outputs
         }


### PR DESCRIPTION
Fix: Fixed ``afjob.py`` to correctly set ``-proj`` flag for Maya renders.
Fix: Fixed ``maya.afanasy``, setting the ``pwd`` flag is breaking texture search path in Maya Arnold.