### PR TITLE
xsi parser bugfix

### DIFF
--- a/afanasy/python/parsers/xsi_arnold.py
+++ b/afanasy/python/parsers/xsi_arnold.py
@@ -6,7 +6,8 @@ import re
 # 00:00:15   325MB         |    20% done - 115 rays/pixel
 re_percent = re.compile(r'(\s*)(\d*)(%\s*done)')
 re_frame = re.compile(r': Rendering frame [0-9]+')
-re_skip = re.compile(r'Skipping Frame')
+re_skip = re.compile(r'Skipping Frame [0-9]+')
+re_exit = re.compile(r'Render completed ')
 
 class xsi_arnold(parser.parser):
 	"""Softimage Arnold
@@ -64,6 +65,12 @@ class xsi_arnold(parser.parser):
 					self.activity = 'rendering..'	
 				if self.percentframe > 99:
 					self.activity = 'finalizing..'
-			
+		
+		match = re_exit.findall(data)
+		if match is not None:
+			if len(match):
+				print("block should be complete...")
+				self.percent = 100
+				self.percentframe = 100
 		
 		self.calculate()

--- a/afanasy/python/parsers/xsi_arnold_watermarked.py
+++ b/afanasy/python/parsers/xsi_arnold_watermarked.py
@@ -6,7 +6,8 @@ import re
 # 00:00:15   325MB         |    20% done - 115 rays/pixel
 re_percent = re.compile(r'(\s*)(\d*)(%\s*done)')
 re_frame = re.compile(r': Rendering frame [0-9]+')
-re_skip = re.compile(r' skipped')
+re_skip = re.compile(r'Skipping Frame [0-9]+')
+re_exit = re.compile(r'Render completed ')
 
 class xsi_arnold_watermarked(parser.parser):
 	"""Softimage Arnold watermarked
@@ -66,5 +67,11 @@ class xsi_arnold_watermarked(parser.parser):
 				if self.percentframe > 99:
 					self.activity = 'finalizing..'
 					
-		
+		match = re_exit.findall(data)
+		if match is not None:
+			if len(match):
+				print("block should be complete...")
+				self.percent = 100
+				self.percentframe = 100
+				
 		self.calculate()

--- a/afanasy/python/parsers/xsi_redshift.py
+++ b/afanasy/python/parsers/xsi_redshift.py
@@ -5,9 +5,9 @@ from parsers import parser
 import re
 # INFO : [Redshift] 	Block 32/48 (7,4) rendered by GPU 0 in 2ms
 re_percent = re.compile(r'(Block*)(\s*)(\d*)(\/)(\d*)(\s*)(\S*)(\s*)(rendered by GPU)')
-# re_frame = re.compile(r'Rendering frame [0-9]+')
 re_frame = re.compile(r': Rendering frame [0-9]+')
-re_skip = re.compile(r' skipped')
+re_skip = re.compile(r'[0-9]+ skipped')
+re_exit = re.compile(r'Render completed ')
 
 class xsi_redshift(parser.parser):
 	"""Softimage Redshift
@@ -90,4 +90,12 @@ class xsi_redshift(parser.parser):
 
 			self.firstframe = False
 
+			
+		match = re_exit.findall(data)
+		if match is not None:
+			if len(match):
+				print("block should be complete...")
+				self.percent = 100
+				self.percentframe = 100
+			
 		self.calculate()


### PR DESCRIPTION
* blocks with tasksize>1 where all frames are being skipped, occasionally
caused clients to error  (the parsers missed the "render completed" line - the task would never complete)