### PR TITLE
Renamed "Preview" to "Launch" in afwatch

### DIFF
--- a/afanasy/src/libafanasy/environment.h
+++ b/afanasy/src/libafanasy/environment.h
@@ -87,7 +87,7 @@ public:
 
 	static inline int            getFileNameSizeMax()  { return filenamesizemax; } ///< Get maximum size for filenames.
 
-	static inline const std::vector<std::string> & getPreviewCmds()     { return previewcmds;} ///< Get preview commands
+	static inline const std::vector<std::string> & getPreviewCmds()     { return previewcmds;} ///< Get launch commands
 	static inline const std::vector<std::string> & getAnnotations()     { return annotations;} ///< Get predefined annotations
 	static inline const std::vector<std::string> & getRenderCmds()      { return rendercmds; } ///< Get render commands
 	static inline const std::vector<std::string> & getRenderCmdsAdmin() { return rendercmds_admin; } ///< Get render commands for admin
@@ -261,7 +261,7 @@ private:
 	static bool perm_user_mod_his_priority;
 	static bool perm_user_mod_job_priority;
 
-	static std::vector<std::string> previewcmds;      ///< Preview commannds
+	static std::vector<std::string> previewcmds;      ///< Launch commannds
 	static std::vector<std::string> annotations;      ///< Predefined annotations
 	static std::vector<std::string> rendercmds;       ///< Render commannds
 	static std::vector<std::string> rendercmds_admin; ///< Render commannds for admin only

--- a/afanasy/src/watch/listtasks.cpp
+++ b/afanasy/src/watch/listtasks.cpp
@@ -151,7 +151,7 @@ void ListTasks::generateMenu(QMenu &o_menu, Item *item)
 				const std::vector<std::string> preview_cmds = af::Environment::getPreviewCmds();
                 if( preview_cmds.size())
                 {
-                    QMenu * submenu_cmd = new QMenu( "Preview", this);
+                    QMenu * submenu_cmd = new QMenu( "Launch", this);
                     for( int i = 0; i < itemBlock->files.size(); i++)
                     {
                         action = new QAction( afqt::stoq(itemBlock->files[i]).right(55), this);
@@ -240,7 +240,7 @@ void ListTasks::generateMenu(QMenu &o_menu, Item *item)
 				const std::vector<std::string> preview_cmds = af::Environment::getPreviewCmds();
 				if( preview_cmds.size())
                 {
-                    QMenu * submenu_cmd = new QMenu( "Preview", this);
+                    QMenu * submenu_cmd = new QMenu( "Launch", this);
                     for( int i = 0; i < files.size(); i++)
                     {
                         action = new QAction( afqt::stoq(files[i]).right(55), this);

--- a/afanasy/src/watch/wndtask.cpp
+++ b/afanasy/src/watch/wndtask.cpp
@@ -509,9 +509,9 @@ void WndTask::showExec( af::MCTask & i_mctask)
 	#endif
 
 	if( parsed_files.size())
-		layout->addWidget( new QLabel("Preview Files (parsed):", m_tab_exec));
+		layout->addWidget( new QLabel("Files (parsed):", m_tab_exec));
 	else
-		layout->addWidget( new QLabel("Preview Files:", m_tab_exec));
+		layout->addWidget( new QLabel("Files:", m_tab_exec));
 	QHBoxLayout * layoutH = new QHBoxLayout();
 	QVBoxLayout * layoutL = new QVBoxLayout();
 	QVBoxLayout * layoutR = new QVBoxLayout();


### PR DESCRIPTION
The "Preview" submenu label has been renamed to "Launch" to match the
same button in task view. No variables has been renamed/changed.