### PR TITLE
Houdini features

### DIFF
--- a/config_default.json
+++ b/config_default.json
@@ -26,6 +26,8 @@
 	"previewcmds":[
 		"Nuke|nuke -v \"@ARG@\"",
 		"Mplay|mplay \"@ARG@\"",
+        "Mplay *|mplay `dirname \"@ARG@\"`/*",
+        "DJV|djv_view \"@ARG@\"",
 		"IMDisplay|display \"@ARG@\"",
 		"XTerm Folder|cd `dirname @ARG@` && xterm"
     ],

--- a/plugins/houdini/afanasy.py
+++ b/plugins/houdini/afanasy.py
@@ -373,8 +373,8 @@ class BlockParameters:
         if self.afnode.parm('render_temp_hip').eval():
             # Calculate temporary hip name:
             ftime = time.time()
-            renderhip = '%s_%s%s%s.hip' % (
-                renderhip,
+            renderhip = '%s/%s%s%s.hip' % (
+                os.path.dirname(renderhip),
                 afcommon.filterFileName(self.job_name),
                 time.strftime('.%m%d-%H%M%S-'),
                 str(ftime - int(ftime))[2:5]


### PR DESCRIPTION
I change naming of .hip files created by Afanasy to more shortest and readable. Sometimes for complex scene naming conventions it's looks huge. Now it looks like:
**origname.afnode.time.ext** 
instead of
**origname.ext_origname.afnode.time.ext**

Also two previewcmd options added:
 - preview all files from directory in Mplay
 - preview file in DJV (popular open source sequence player)