### PR TITLE
Http server refactor

### DIFF
--- a/afanasy/src/libafanasy/name_af.h
+++ b/afanasy/src/libafanasy/name_af.h
@@ -255,7 +255,9 @@ namespace af
 	/// Send message \c msg to given file discriptor
 	/** Return true if success.**/
 	bool msgwrite( int i_desc, const af::Msg * i_msg);
-	char * msgMakeWriteHeader( const af::Msg * i_msg);
+
+	std::string msgMakeWriteHeader( const af::Msg * i_msg);
+	std::string getHttpHeader(int file_size, const std::string &mimeType, const std::string &status);
 
 	/// Send a message to all its addresses and receive an answer if needed
 	Msg * sendToServer( Msg * i_msg, bool & o_ok, VerboseMode i_verbose);

--- a/afanasy/src/server/httpget.cpp
+++ b/afanasy/src/server/httpget.cpp
@@ -1,3 +1,5 @@
+#include "httpget.hpp"
+
 #include "../include/afanasy.h"
 
 #include "../libafanasy/environment.h"
@@ -10,47 +12,94 @@
 #include "../include/macrooutput.h"
 #include "../libafanasy/logger.h"
 
-bool httpGetValidateFileName( const std::string & i_name);
+std::vector<char *> HttpGet::http_get_blacklist_files = {
+	"..",		// do not allow escaping the document root of the webserver
+	"htdigest", // do not allow access to the .htdigest file
+	"htaccess", // do not allow access to the .htaccess file
+	".json"		// do not allow access to any json file
+};
 
-af::Msg * httpGet( const af::Msg * i_msg)
+af::Msg *HttpGet::process(const af::Msg *i_msg)
 {
-	//static const char header_OK[] = "HTTP/1.1 200 OK\r\n\r\n";
-	//static const  int header_OK_len = strlen( header_OK);
-	//static const char header_ERROR[] = "HTTP/1.1 404 Not Found\r\n\r\n";
+	af::Msg *o_msg = new af::Msg();
+
+	const std::string file_name = HttpGet::getFileNameFromInMsg(i_msg);
+	const std::string mimeType = HttpGet::getMimeTypeFromFileName(file_name);
+
+	// ### copy the file with proper http header to the output
+	int file_size;
+	char *file_data = NULL;
+	if (file_name.size())
+	{
+		std::string error;
+		file_data = af::fileRead(file_name, &file_size, -1, &error);
+	}
+
+	if (file_data)
+	{
+		std::string httpHeader = af::getHttpHeader(file_size, mimeType, "200 OK");
+
+		// combine http header with file content into msg_data
+		int msg_data_len = httpHeader.length() + file_size;
+		char *msg_data = new char[msg_data_len];
+		memcpy(msg_data, httpHeader.c_str(), httpHeader.length());
+		memcpy(msg_data + httpHeader.length(), file_data, file_size);
+
+		o_msg->setData(msg_data_len, msg_data, af::Msg::THTTPGET);
+
+		delete[] file_data;
+		delete[] msg_data;
+	}
+	else
+	{
+		std::string outputText404 = HttpGet::get404Content(file_name);
+		std::string output404 = af::getHttpHeader(outputText404.length(), mimeType, "404 Not Found");
+		output404 += outputText404;
+		o_msg->setData(output404.size(), output404.c_str(), af::Msg::THTTPGET);
+	}
+
+	return o_msg;
+}
+
+std::string HttpGet::getFileNameFromInMsg(const af::Msg *i_msg)
+{
+	std::string file_name;
 
 	static const char tasks_file[] = "@TMP@";
-	static const  int tasks_file_len = strlen( tasks_file);
+	static const int tasks_file_len = strlen(tasks_file);
 
-	af::Msg * o_msg = new af::Msg();
-
-	char * get = i_msg->data();
+	char *get = i_msg->data();
 	int get_len = i_msg->dataLen();
 	//::write( 1, get, get_len);
 	int get_start = 4; // skipping "GET "
-	int get_finish = get_start; 
-	while( get[++get_finish] != ' ');
-	while( get[get_start] == '/' ) get_start++;
-	while( get[get_start] == '\\') get_start++;
+	int get_finish = get_start;
+	while (get[++get_finish] != ' ')
+		;
+	while (get[get_start] == '/')
+		get_start++;
+	while (get[get_start] == '\\')
+		get_start++;
 
-	std::string file_name;
-	if( get_finish - get_start > 1 )
+	if (get_finish - get_start > 1)
 	{
-		file_name = std::string( get + get_start, get_finish - get_start);
-		if( false == httpGetValidateFileName( file_name))
+		file_name = std::string(get + get_start, get_finish - get_start);
+		if (false == HttpGet::getValidateFileName(file_name))
 		{
-			AFCommon::QueueLogError("GET: Invalid file name from " + i_msg->getAddress().v_generateInfoString() + "\n" + file_name);
+			AFCommon::QueueLogError("GET: Invalid file name from "
+									+ i_msg->getAddress().v_generateInfoString() + "\n" + file_name);
 			file_name.clear();
 		}
-		else if( file_name.find( tasks_file) == 0 )
+		else if (file_name.find(tasks_file) == 0)
 		{
 			get_start += tasks_file_len;
-			file_name = std::string( get + get_start, get_finish - get_start);
-			if( file_name.find( af::Environment::getStoreFolder()) != 0 )
+			file_name = std::string(get + get_start, get_finish - get_start);
+			if (file_name.find(af::Environment::getStoreFolder()) != 0)
 			{
-				AFCommon::QueueLogError("GET: Invalid @TMP@ folder from " + i_msg->getAddress().v_generateInfoString() + "\n" + file_name);
+				AFCommon::QueueLogError("GET: Invalid @TMP@ folder from "
+										+ i_msg->getAddress().v_generateInfoString() + "\n" + file_name);
 				file_name.clear();
 			}
-//printf("GET TMP FILE: %s\n", file_name.c_str());
+			// printf("GET TMP FILE: %s\n", file_name.c_str());
 		}
 		else
 		{
@@ -61,58 +110,41 @@ af::Msg * httpGet( const af::Msg * i_msg)
 	{
 		file_name = af::Environment::getHTTPServeDir() + AFGENERAL::HTML_BROWSER;
 	}
-
-//printf("GET[%d,%d]=%s\n", get_start, get_finish, file_name.c_str());
-
-	int file_size;
-	char * file_data = NULL;
-	if( file_name.size())
-	{
-		std::string error;
-		file_data = af::fileRead( file_name, &file_size, -1, &error);
-	}
-
-	if( file_data )
-	{
-		char buffer[1024];
-		sprintf( buffer, "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: %d\r\n\r\n", file_size);
-		int buffer_len = strlen( buffer);
-
-//		int msg_datalen = header_OK_len + file_size;
-		int msg_datalen = buffer_len + file_size;
-		char * msg_data = new char[msg_datalen];
-
-//		memcpy( msg_data, header_OK, header_OK_len);
-		memcpy( msg_data, buffer, buffer_len);
-		memcpy( msg_data + buffer_len, file_data, file_size);
-
-		o_msg->setData( msg_datalen, msg_data, af::Msg::THTTPGET);
-
-		delete [] file_data;
-		delete [] msg_data;
-	}
-	else
-	{
-		std::string error("HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n");
-		error += "File not found: ";
-		error += file_name;
-		o_msg->setData( error.size(), error.c_str(), af::Msg::THTTPGET);
-	}
-
-	return o_msg;
+	return file_name;
 }
 
-static const char * files_skip[] = {
-/*1*/"..",
-/*2*/"htdigest",
-/*3*/"htaccess",
-/*4*/".json"
-};
-bool httpGetValidateFileName( const std::string & i_name)
+std::string HttpGet::getMimeTypeFromFileName(const std::string &filename)
 {
-	for( int i = 0; i < 4; i++)
-		if( i_name.find( files_skip[i]) != -1 ) return false;
+	const std::string extension = filename.substr(filename.find_last_of(".") + 1);
+	if (extension == "css") return "text/css";
+	if (extension == "js") return "text/javascript";
+	if (extension == "png") return "image/png";
+	if (extension == "jpeg" || extension == "jpg") return "image/jpeg";
+	if (extension == "gif") return "image/gif";
+
+	return "text/html; charset=UTF-8";
+}
+
+bool HttpGet::getValidateFileName(const std::string &i_name)
+{
+	// do not serve files, which match an entry on the blacklist
+	for (int i = 0; i < http_get_blacklist_files.size(); i++)
+		if (i_name.find(http_get_blacklist_files[i]) != -1) return false;
 
 	return true;
 }
 
+std::string HttpGet::get404Content(const std::string &filename)
+{
+	return std::string("<!DOCTYPE html><html><head><meta charset=\"UTF-8\"><title>AFANASY 404</title>")
+				 + "<link type=\"text/css\" rel=\"stylesheet\" href=\"lib/styles.css\">"
+				 + "<link type=\"text/css\" rel=\"stylesheet\" href=\"afanasy/browser/style.css\">"
+				 + "</head><body id=\"afbody\" style=\"position: absolute; top: 50%;"
+				 + "transform: translateY(-50%); text-align: center; width: 100%\">"
+				 + "<span style=\"font-size: 30px;\">Arghh, page not found!</span><br>"
+				 + "<span style=\"font-size: 100px; font-weight: bold;\">¯\\_(ツ)_/¯<br>404 Error</span><br>"
+				 + "<span style=\"font-size: 20px;\">The requested file (" + filename
+				 + ") could not be found on the server.</span><br>"
+				 + "<span style=\"font-size: 15px;\">Contact the <a href=\"http://forum.cgru.info/\">forum</a>, "
+				 + "if you think this is an error.</span></body></html>";
+}

--- a/afanasy/src/server/httpget.hpp
+++ b/afanasy/src/server/httpget.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "../include/afanasy.h"
+
+#include "../libafanasy/environment.h"
+#include "../libafanasy/msg.h"
+
+class HttpGet
+{
+public:
+	static af::Msg *process(const af::Msg *i_msg);
+
+private:
+	static std::vector<char *> http_get_blacklist_files;
+
+	static std::string getFileNameFromInMsg(const af::Msg *i_msg);
+	static bool getValidateFileName(const std::string &i_name);
+	static std::string getHttpHeader(int file_size, const std::string &mimeType, const std::string &status);
+	static std::string getMimeTypeFromFileName(const std::string &filename);
+	static std::string get404Content(const std::string &filename);
+};

--- a/examples/test scripts/setup_pgsql.sh
+++ b/examples/test scripts/setup_pgsql.sh
@@ -19,14 +19,19 @@ if [ ! -f $pg_conf ]; then
    exit 1
 fi
 
-# Add required config line to the PostgreSQL configuration:
-su - $pg_user -c "echo \"# Afanasy:\" >> $pg_conf; echo \"local afanasy afadmin password\" >> $pg_conf"
+# Add required config line to the PostgreSQL configuration, if not yet exists
+afanasyConfigGrep=$(grep 'Afanasy Database' $pg_conf)
+if [[ "$afanasyConfigGrep" == "" ]]; then
+  su - $pg_user -c "echo \"\" >> $pg_conf"
+  su - $pg_user -c "echo \"##### Afanasy Database ######\" >> $pg_conf"
+  su - $pg_user -c "echo \"local afanasy afadmin password\" >> $pg_conf"
+fi
 
 # Start PostgreSQL service:
 systemctl start postgresql
 
 # Create database and user
-su - $pg_user -c "psql -d $db_name -c \"CREATE DATABASE IF NOT EXISTS ${db_name};\""
+su - $pg_user -c "createdb $db_name;"
 su - $pg_user -c "psql -d $db_name -c \"CREATE USER ${db_user} PASSWORD '${db_passwd}';\""
 
 # Check connection and create tables


### PR DESCRIPTION
 refactor and rework of the http GET server and http response

added proper http header for GET and JSON requests, containing:
- Connection: close - instruct browser to close connection after receive
- Content-Length: length -  tell how long the content is
- Content-Type: mimeType -  set the mimetype of the result
- Cache-Control: max-age=ttl -  optional browser caching
- Server: afanasy/[VersionCGRU] -  identify server

This removes browser warnings about incorrect mime types (chrome) and
instructs the browser to cache js / css / image ressources.

This commit also contains misc refactoring and simplification.

msgMakeWriteHeader (dynamic JSON data) and GET requests confirmed
functional,responses of type: Msg::TJSON not tested, but should be OK

```
header = std::string("AFANASY ") + std::to_string(size) + " JSON";
```