### PR TITLE
Added the number of frames per task to the statistics database

### DIFF
--- a/afanasy/src/libafanasy/taskexec.h
+++ b/afanasy/src/libafanasy/taskexec.h
@@ -60,6 +60,7 @@ public:
 	// Get task data:
 	inline int getTaskNum()  const { return m_task_num;    }///< Get task number in block.
 	inline int getNumber()   const { return m_number;     }///< Get task number (aux).
+	inline int getFramesNumber() const { return m_frames_num; }///< Get task number of frames.
 
 	// Get block data:
 	inline const std::string & getBlockName() const { return m_block_name; }

--- a/afanasy/src/libafsql/dbtask.cpp
+++ b/afanasy/src/libafsql/dbtask.cpp
@@ -27,6 +27,7 @@ DBTask::DBTask()
 	dbAddAttr( new DBAttrInt64 ( DBAttr::_time_done,    &m_time_done    ));
 	dbAddAttr( new DBAttrInt64 ( DBAttr::_time_started, &m_time_start   ));
 	dbAddAttr( new DBAttrString( DBAttr::_username,     &m_username     ));
+	dbAddAttr( new DBAttrInt32 ( DBAttr::_frame_pertask, &m_frame_pertask ));
 }
 
 DBTask::~DBTask()
@@ -47,6 +48,7 @@ void DBTask::add(
 	m_blockname = i_exec->getBlockName();
 	m_service   = i_exec->getServiceType();
 	m_capacity  = i_exec->getCapacity();
+	m_frame_pertask = i_exec->getFramesNumber();
 
 	m_starts_count = i_progress->starts_count;
 	m_errors_count = i_progress->errors_count;

--- a/afanasy/src/libafsql/dbtask.h
+++ b/afanasy/src/libafsql/dbtask.h
@@ -36,6 +36,7 @@ private:
 	int32_t m_error;
 	int32_t m_starts_count;
 	int32_t m_errors_count;
+	int32_t m_frame_pertask;
 
 	int64_t m_time_done;
 	int64_t m_time_start;


### PR DESCRIPTION
Pull request for #398 
Used the "_frame_pertask" db attribute which seemed unused