### PR TITLE
fix afermer linking errors

### DIFF
--- a/afanasy/src/project.cmake/fermer/CMakeLists.txt
+++ b/afanasy/src/project.cmake/fermer/CMakeLists.txt
@@ -68,6 +68,8 @@ set (watch_cpp_src
 		"../..//watch/receiver.cpp"
 		"../..//watch/ctrlsortfiltermenu.cpp"
 		"../..//watch/offlinescreen.cpp"
+		"../../watch/buttondblclick.cpp"
+		"../../watch/qaftextwidget.cpp"
 		 )
 
 if(WIN32)


### PR DESCRIPTION
fix for afermer errors during linking stage such:
```
CMakeFiles/afermer.dir/mnt/users/arifulov/home/repos/cgru/afanasy/src/watch/wndtask.cpp.o: In function `WndTask::createTab(QString const&, QWidget**, QAfTextWidget**)':
wndtask.cpp:(.text+0x10b): undefined reference to `QAfTextWidget::QAfTextWidget(QWidget*)'
CMakeFiles/afermer.dir/mnt/users/arifulov/home/repos/cgru/afanasy/src/watch/wndtask.cpp.o: In function `WndTask::updateProgress(af::TaskProgress const&)':
wndtask.cpp:(.text+0x40e0): undefined reference to `ButtonDblClick::setEnabled(bool)'
wndtask.cpp:(.text+0x40fb): undefined reference to `ButtonDblClick::setEnabled(bool)'
wndtask.cpp:(.text+0x44d2): undefined reference to `ButtonDblClick::setEnabled(bool)'
wndtask.cpp:(.text+0x4503): undefined reference to `ButtonDblClick::setEnabled(bool)'
CMakeFiles/afermer.dir/mnt/users/arifulov/home/repos/cgru/afanasy/src/watch/wndtask.cpp.o: In function `WndTask::WndTask(af::MCTaskPos const&, ListTasks*)':
wndtask.cpp:(.text+0x55ed): undefined reference to `ButtonDblClick::ButtonDblClick(QString const&, QWidget*)'
wndtask.cpp:(.text+0x5633): undefined reference to `ButtonDblClick::setEnabled(bool)'
wndtask.cpp:(.text+0x568f): undefined reference to `ButtonDblClick::ButtonDblClick(QString const&, QWidget*)'
wndtask.cpp:(.text+0x56d5): undefined reference to `ButtonDblClick::setEnabled(bool)'
```