### PR TITLE
Update taskprocess.cpp

### DIFF
--- a/afanasy/src/render/taskprocess.cpp
+++ b/afanasy/src/render/taskprocess.cpp
@@ -189,7 +189,9 @@ void TaskProcess::launchCommand()
 	// On windows we attach process to a job to close all spawned childs:
 	m_hjob = CreateJobObject( NULL, NULL);
 	JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli = { 0 };
-	jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+	jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | 
+						JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION | 
+						JOB_OBJECT_LIMIT_BREAKAWAY_OK;
 	if( SetInformationJobObject( m_hjob, JobObjectExtendedLimitInformation, &jeli, sizeof( jeli ) ) == 0)
 		AFERROR("SetInformationJobObject failed.\n");
 	if( AssignProcessToJobObject( m_hjob, m_pinfo.hProcess) == false)


### PR DESCRIPTION
Флаг JOB_OBJECT_LIMIT_BREAKAWAY_OK разрешает создание дочернего процесса вне объекта задания.