### PR TITLE
Added support to render on individual GPUs with Redshift.

### DIFF
--- a/plugins/houdini/afanasy.py
+++ b/plugins/houdini/afanasy.py
@@ -458,12 +458,13 @@ class BlockParameters:
             sec = now_sec % 60
             wait_sec = now_day + (hours * 3600) + (minutes * 60) + sec
             if wait_sec <= now_sec:
-                if hou.ui.displayMessage(
-                            'Now is greater than %d:%d\nOffset by 1 day?' % (hours, minutes),
-                            buttons=('Offset', 'Abort'),
-                            default_choice=0, close_choice=1,
-                            title='Wait Time'
-                        ) == 0:
+                result = hou.ui.displayMessage(
+                    'Now is greater than %d:%d\nOffset by 1 day?' % (hours, minutes),
+                    buttons=('Offset', 'Abort'),
+                    default_choice=0, close_choice=1,
+                    title='Wait Time'
+                )
+                if result == 0:
                     wait_sec += (24*3600)
                 else:
                     return

--- a/plugins/houdini/hrender_af.py
+++ b/plugins/houdini/hrender_af.py
@@ -86,9 +86,9 @@ if rop[0] != '/':
 ropnode = hou.node(rop)
 
 if ropnode is None:
-    raise hou.InvalidNodeName(rop + ' rop node wasn`t found')
+    raise hou.InvalidNodeName(rop + " rop node wasn't found")
 
-# Trying to set ROP to block until render comletes
+# Trying to set ROP to block until render completes
 # block = ropnode.parm('soho_foreground')
 # if block != None:
 # value = block.eval()
@@ -225,6 +225,11 @@ elif drivertypename == "Redshift_ROP":
         hou.hscript("Redshift_setLogLevel -L 5")
     except:
         print('Failed, frame progress not available.')
+
+    # Try setting separate GPU masks
+    if 'GPU_MASK' in os.environ:
+        mask = os.environ['GPU_MASK']
+        hou.hscript('Redshift_setGPU -s %s' % mask)
 
 #
 # Distribute simulation:

--- a/software_setup/bin/mayarender
+++ b/software_setup/bin/mayarender
@@ -2,4 +2,9 @@
 
 source $CGRU_LOCATION/software_setup/setup_maya.sh
 
-"$APP_DIR/bin/Render" "$@"
+
+if [ -z "$GPU_LIST" ]; then
+        "$APP_DIR/bin/Render" "$@"
+else
+        "$APP_DIR/bin/Render" -r redshift -gpu $GPU_LIST "$@"
+fi

--- a/software_setup/bin/mayarender.cmd
+++ b/software_setup/bin/mayarender.cmd
@@ -2,4 +2,8 @@
 
 call %CGRU_LOCATION%\software_setup\setup_maya.cmd
 
-"%APP_DIR%\bin\Render.exe" %*
+if "%GPU_LIST%" == "" (
+    "%APP_DIR%\bin\Render.exe" %*
+) else (
+    "%APP_DIR%\bin\Render.exe" -r redshift -gpu %GPU_LIST% %*
+)


### PR DESCRIPTION
With this PR it is possible to set ``GPU_MASK`` environment variable to select a subset of the GPUs on the system for render with Redshift for Houdini.

This will allow the client to be able to render on all of the GPUs separately by running a new client (``afrender``) for each GPU with each setting a different ``GPU_MASK`` environment variable (ex. to enable GPU0 use ``1000``, to enable GPU1 use ``0100``, for GPU2 ``0010`` and for GPU3 use ``0001``) and a proper ``HOSTNAME`` (ex. ``${HOSTNAME}_GPU0``, ``${HOSTNAME}_GPU1``, ``${HOSTNAME}_GPU2``, ``${HOSTNAME}_GPU3``).

For example the following script will start an ``afrender`` with only the first GPU enabled:
```
#!/usr/bin/bash

# set GPU_MASK for Houdini
export GPU_MASK=1000

/opt/cgru/start/AFANASY/_afrender.sh -hostname ${HOSTNAME}_GPU0
```

changing the variables accordingly (the ``GPU_MASK`` and the hostname part) one can spawn as many ``afrender`` client as there are GPUs on the system and they will act as separate clients.

See the [Redshift Houdini Documentation](https://docs.redshift3d.com/display/RSDOCS/Command-line+Rendering+and+GPU+Selection?product=houdini) on this subject.