### PR TITLE
remove args in setFree() call

### DIFF
--- a/utilities/keeper/nimby.py
+++ b/utilities/keeper/nimby.py
@@ -114,6 +114,6 @@ def refresh(reset=False):
 			free_set = False
 	elif toset_free:
 		if not free_set:
-			setFree('(keeper nimby schedule)')
+			setFree()
 			free_set = True
 			nimby_set = False


### PR DESCRIPTION
... line 113, in refresh
    setFree('(keeper nimby schedule)')
TypeError: setFree() takes 0 positional arguments but 1 was given
