### PR TITLE
Fix 'WRC' state on append of tasks/blocks

### DIFF
--- a/afanasy/src/server/block.cpp
+++ b/afanasy/src/server/block.cpp
@@ -768,6 +768,6 @@ bool Block::appendTasks(const JSON &operation)
 	storeTasks();
 
 	// Set new tasks ready
-	m_job->checkStates();
+	m_job->checkStatesOnAppend();
 	return true;
 }

--- a/afanasy/src/server/jobaf.cpp
+++ b/afanasy/src/server/jobaf.cpp
@@ -331,6 +331,26 @@ void JobAf::checkStates()
 	if(( m_state & AFJOB::STATE_DONE_MASK) == false ) m_state = m_state | AFJOB::STATE_WAITDEP_MASK;
 }
 
+void JobAf::checkStatesOnAppend()
+{
+	for( int b = 0; b < m_blocks_num; b++)
+	{
+		int numtasks = m_blocks_data[b]->getTasksNum();
+		for( int t = 0; t < numtasks; t++)
+		{
+			uint32_t taskstate = m_progress->tp[b][t]->state;
+
+			if( taskstate == 0 )
+			{
+				taskstate = AFJOB::STATE_READY_MASK;
+				m_progress->tp[b][t]->state = taskstate;
+			}
+		}
+	}
+
+	if(( m_state & AFJOB::STATE_DONE_MASK) == false ) m_state = m_state | AFJOB::STATE_WAITDEP_MASK;
+}
+
 int JobAf::getUid() const { return m_user->getId(); }
 
 void JobAf::deleteNode( RenderContainer * renders, MonitorContainer * monitoring)
@@ -1651,5 +1671,5 @@ void JobAf::appendBlocks( const JSON & i_blocks)
 	}
 
 	checkDepends();
-	checkStates();
+	checkStatesOnAppend();
 }

--- a/afanasy/src/server/jobaf.h
+++ b/afanasy/src/server/jobaf.h
@@ -91,6 +91,7 @@ public:
 
 	/// Set state of new tasks
 	void checkStates();
+	void checkStatesOnAppend();
 
 	int getUid() const;
 


### PR DESCRIPTION
When appending blocks or tasks to an existing job or block
the already existing ones are set to a 'WRC' state because of
the 'checkState' call but the client never sends the appropriate
reconnect signal.

The code changes in this PR moves the task initialization into it's own
method in JobAf that is only called on append and does not do the overall checks
'checkStates' does that lead to the problem.

Please review and give comments if there are things I missed and that could
cause misbeheaviour.

Thanks,
Yannic