### PR TITLE
Appended flags

### DIFF
--- a/afanasy/python/afcmd.py
+++ b/afanasy/python/afcmd.py
@@ -3,6 +3,7 @@
 import json
 import cgruconfig
 import afnetwork
+import afcommon
 
 
 class Block:
@@ -90,7 +91,10 @@ class Block:
         self.setState(self.State.skip, taskIds=taskIds)
 
     def isNumeric(self):
-        return bool(self.flags >> 0)
+        return afcommon.checkBlockFlag(self.flags, 'numeric')
+
+    def hasAppendedTasks(self):
+        return afcommon.checkBlockFlag(self.flags, 'appendedtasks')
 
     def appendTasks(self, tasks, verbose=False):
         """Append new tasks to an existing block
@@ -100,7 +104,7 @@ class Block:
         :return: server response
         """
         output = "The block is numeric and cannot have tasks appended"
-        if self.isNumeric() is False:
+        if not self.isNumeric():
             tasks_data = []
             for t in tasks:
                 tasks_data.append(t.data)
@@ -216,6 +220,9 @@ class Job:
             if 'job_progress' in output:
                 return output['job_progress']
         return None
+
+    def hasAppendedBlocks(self):
+        return afcommon.checkJobFlag(self.flags, 'appendedblocks')
 
     def appendBlocks(self, blocks, verbose=False):
         """Append new blocks to an existing job

--- a/afanasy/python/afcmd.py
+++ b/afanasy/python/afcmd.py
@@ -91,7 +91,7 @@ class Block:
         self.setState(self.State.skip, taskIds=taskIds)
 
     def isNumeric(self):
-        return afcommon.checkBlockFlag(self.flags, 'numeric')
+        return bool(afcommon.checkBlockFlag(self.flags, 'numeric'))
 
     def hasAppendedTasks(self):
         return afcommon.checkBlockFlag(self.flags, 'appendedtasks')

--- a/afanasy/python/afcommon.py
+++ b/afanasy/python/afcommon.py
@@ -13,7 +13,17 @@ BlockFlags = {
     'skipthumbnails':     1 << 5,
     'skipexistingfiles':  1 << 6,
     'checkrenderedfiles': 1 << 7,
-    'slavelostignore':    1 << 8
+    'slavelostignore':    1 << 8,
+    'appendedtasks':      1 << 9
+}
+
+JobFlags = {
+	# First 32 flags are reserved for af::Node (zombie, hidden, ...)
+    'ppapproval':     1 << 32,
+    'maintenance':    1 << 33,
+    'ignorenimby':    1 << 34,
+    'ignorepaused':   1 << 35,
+    'appendedblocks': 1 << 36
 }
 
 
@@ -29,6 +39,26 @@ def setBlockFlag(i_flags, i_name):
     if i_name not in BlockFlags:
         print('AFERROR: block flag "%s" does not exist.' % i_name)
         print('Existing flags are: ' + str(BlockFlags))
+        return i_flags
+    elif i_name == 'appendedtasks':
+        print('AFERROR: block flag "%s" is read-only.' % i_name)
+        return i_flags
+    return i_flags | BlockFlags[i_name]
+
+def checkJobFlag(i_flags, i_name):
+    if i_name not in JobFlags:
+        print('AFERROR: block flag "%s" does not exist.' % i_name)
+        print('Existing flags are: ' + str(BlockFlags))
+        return False
+    return i_flags & BlockFlags[i_name]
+
+def setJobFlag(i_flags, i_name):
+    if i_name not in JobFlags:
+        print('AFERROR: job flag "%s" does not exist.' % i_name)
+        print('Existing flags are: ' + str(JobFlags))
+        return i_flags
+    elif i_name == 'appendedblocks':
+        print('AFERROR: job flag "%s" is read-only.' % i_name)
         return i_flags
     return i_flags | BlockFlags[i_name]
 

--- a/afanasy/src/libafanasy/blockdata.cpp
+++ b/afanasy/src/libafanasy/blockdata.cpp
@@ -339,6 +339,8 @@ void BlockData::jsonReadAndAppendTasks(const JSON &i_object)
 
 	if (NULL != old_tasks_data)
 		delete [] old_tasks_data;
+
+	setHasAppendedTasks();
 }
 
 void BlockData::jsonWrite(std::ostringstream &o_str, const std::string &i_datamode) const

--- a/afanasy/src/libafanasy/blockdata.h
+++ b/afanasy/src/libafanasy/blockdata.h
@@ -58,7 +58,8 @@ public:
 		FSkipThumbnails = 1ULL << 5,
 		FSkipExistingFiles = 1ULL << 6,
 		FCheckRenderedFiles = 1ULL << 7,
-		FSlaveLostIgnore = 1ULL << 8
+		FSlaveLostIgnore = 1ULL << 8,
+		FAppendedTasks = 1ULL << 9
 	};
 
 	static const char DataMode_Progress[];
@@ -118,6 +119,15 @@ public:
 	{
 		return m_flags & FDependSubTask;
 	} ///< Other block can depend this block sub task
+	inline bool hasAppendedTasks() const
+	{
+		return m_flags & FAppendedTasks;
+	} ///< Wether the block has appended tasks
+
+	inline void setHasAppendedTasks()
+	{
+		m_flags |= FAppendedTasks;
+	} ///< Set flag on the block signaling that it has tasks appended
 
 	inline bool isSkippingExistingFiles() const {return m_flags & FSkipExistingFiles;}
 	inline bool isCheckingRenderedFiles() const {return m_flags & FCheckRenderedFiles;}

--- a/afanasy/src/libafanasy/job.cpp
+++ b/afanasy/src/libafanasy/job.cpp
@@ -161,6 +161,9 @@ bool Job::jsonReadAndAppendBlocks( const JSON &i_blocks)
 			return false;
 		}
 	}
+
+	setAppendedBlocksFlag();
+
 	return true;
 }
 

--- a/afanasy/src/libafanasy/job.h
+++ b/afanasy/src/libafanasy/job.h
@@ -55,7 +55,8 @@ public:
 		FPPApproval   = 1ULL << 32,
 		FMaintenance  = 1ULL << 33,
 		FIgnoreNimby  = 1ULL << 34,
-		FIgnorePaused = 1ULL << 35
+		FIgnorePaused = 1ULL << 35,
+		FAppendedBlocks = 1ULL << 36
 	};
 
 	inline int64_t getSerial() const { return m_serial; }
@@ -103,6 +104,9 @@ public:
 
     inline bool isIgnorePausedFlag() const { return ( m_flags & FIgnorePaused ); }
     inline void setIgnorePausedFlag( bool i_on = true) { if( i_on ) m_flags = m_flags | FIgnorePaused; else m_flags = m_flags & (~FIgnorePaused); }
+
+    inline bool isAppendedBlocksFlags() const { return ( m_flags & FAppendedBlocks ); }
+    inline void setAppendedBlocksFlag() { m_flags |= FAppendedBlocks; }
 
 	inline bool setDependMask(        const std::string & str, std::string * errOutput = NULL)
 		{ return setRegExp( m_depend_mask, str, "job depend mask", errOutput);}


### PR DESCRIPTION
To use the feature to append blocks and tasks to already running jobs it might come in handy to query 
from a job if it has appended blocks or from a block if it has appended tasks. Therefore this PR adds flags 
to the job and blockdata to specify this. 

It further extends the python API to check if the flag is set. The afcommon module did not provide job flags for now that are added.
The corresponding setter are treating the 'appendedtasks' and 'appendedblocks' as read only.

Additionally there is a small fix regarding the 'isNumeric' and 'appendBlocks' functions in afcmd, that did not return the correct flag value and used a 'False' check that did not work correctly in python.

Please review and let me know what you think about this additions.

Thanks,
Yannic