### PR TITLE
#485 change WDP state behaviour for dependant jobs

### DIFF
--- a/afanasy/src/server/jobaf.cpp
+++ b/afanasy/src/server/jobaf.cpp
@@ -655,6 +655,9 @@ void JobAf::setUserListOrder( int index, bool updateDtabase)
 void JobAf::checkDepends()
 {
 	m_state = m_state & (~AFJOB::STATE_WAITDEP_MASK);
+
+	if ( ( m_state & AFJOB::STATE_DONE_MASK ) == AFJOB::STATE_DONE_MASK )
+		return;
 	
 	bool depend_local = false;
 	bool depend_global = false;


### PR DESCRIPTION
If a job has a DON state but is dependent of another job that is
restarted, the job state is set to DON WDP. Skipping the dependance
check for job with a DON state doesn't set the WDP state mask anymore so that the job state is DON only.


Hi Timur, please review and give feedback! This works on our side and while testing I didn't recognize any unwanted side-effects.
The issue #485 mentions this problem.

Thanks,
Yannic