### PR TITLE
Updated Maya and Redshift parsers

### DIFF
--- a/afanasy/python/parsers/maya.py
+++ b/afanasy/python/parsers/maya.py
@@ -14,5 +14,7 @@ class maya(parser.parser):
             'Frame aborted',
             'Frame rendering aborted',
             'Fatal Error',
+            'Maya exited with status 210',
+            'failed to render',
             '(kFailure)',
         ]

--- a/afanasy/python/parsers/redshift.py
+++ b/afanasy/python/parsers/redshift.py
@@ -26,12 +26,10 @@ class redshift(parser.parser):
         self.data_all = ''
 
         self.str_error += [
-            '[Redshift]No devices found. Aborting rendering.',
-            'Frame aborted',
-            'Frame rendering aborted',
+            'No devices found. Aborting rendering.',
+            'Rendering was internally aborted',
             'Bad node type found: Redshift_ROP',
             'Bad node type found: redshift_vopnet',
-            'Fatal Error',
             'Error an illegal memory access was encountered',
         ]
 

--- a/afanasy/python/parsers/redshift.py
+++ b/afanasy/python/parsers/redshift.py
@@ -31,10 +31,8 @@ class redshift(parser.parser):
             'Bad node type found: Redshift_ROP',
             'Bad node type found: redshift_vopnet',
             'Error an illegal memory access was encountered',
+            'License error',
         ]
-
-        self.str_badresult += ['License error']
-        self.str_warning = []
 
         self.block = 0
         self.block_count = 0


### PR DESCRIPTION
As mentioned in #494 updated Maya and Redshift parsers to have unique error message lists. Also updated Redshift parser and moved ``License error`` message from ``str_bad_result`` to ``str_error`` due to the change in latest versions of Redshift which aborts the render on license error instead of putting watermarks on top of the render.