### PR TITLE
Fix build error in Gentoo

### DIFF
--- a/afanasy/src/project.cmake/build.sh
+++ b/afanasy/src/project.cmake/build.sh
@@ -54,6 +54,7 @@ case ${DISTRIBUTIVE} in
         export AF_ADD_LFLAGS="$AF_ADD_LFLAGS -lpthread -lrt"
         ;;
     Gentoo)
+	export AF_EXTRA_LIBS="pthread"
         ;;
     Ubuntu)
         export ADD_CMAKE_MODULE_PATH="$PWD"


### PR DESCRIPTION
When building Afanasy on Gentoo, I added this line to fix a "DSO missing from command line" error.