### PR TITLE
Add thumbnails for redshift parser

### DIFF
--- a/afanasy/python/parsers/redshift.py
+++ b/afanasy/python/parsers/redshift.py
@@ -22,6 +22,7 @@ re_triangles = re.compile(r'(.*)(Total triangles:)(\s*)(\d*)')
 re_frame_start = re.compile(r'.*Rendering.*frame [0-9]+\.\.\.')
 re_frame_skip = re.compile(r'.*Skipping frame.*')
 re_frame_done = re.compile(r'.*Frame.*done.*')
+re_image = re.compile(r"Saving:\s(.+)")
 
 
 class redshift(parser.parser):
@@ -94,6 +95,11 @@ class redshift(parser.parser):
 
         if self.percentframe < percent:
             self.percentframe = int(percent)
+
+        match = re_image.search(data)
+        if match:
+            file_path = match.group(1)
+            self.appendFile(file_path.strip(), True)
 
         match = re_frame_done.findall(data)
         if match:


### PR DESCRIPTION
Adds the ability for previews to be generated by Redshift.

Tested on Windows 10 with 
* Houdini-19.5.368 +  redshift-3.5.09
* Houdini-19.0.561 + redshift-3.0.67 