### PR TITLE
Added prefix to window title with server address in all contexts

### DIFF
--- a/afanasy/src/watch/listitems.cpp
+++ b/afanasy/src/watch/listitems.cpp
@@ -653,3 +653,7 @@ void ListItems::changeParam(const Param * i_param)
 	setParameter(i_param->itemtype, afqt::qtos(i_param->name), afqt::qtos(str));
 }
 
+void ListItems::setWindowTitleWithPrefix(QString windowTitle)
+{
+    m_parentWindow->setWindowTitle(QString("(%1) %2").arg(af::Environment::getServerName().c_str(), windowTitle));
+}

--- a/afanasy/src/watch/listitems.h
+++ b/afanasy/src/watch/listitems.h
@@ -128,6 +128,8 @@ protected:
 		bool i_dblclick = false,
 		bool i_always_active = false);
 
+	void setWindowTitleWithPrefix(QString windowTitle);
+
 protected:
 
 	Item * m_current_item;

--- a/afanasy/src/watch/listjobs.cpp
+++ b/afanasy/src/watch/listjobs.cpp
@@ -227,7 +227,7 @@ ListJobs::ListJobs(QWidget * i_parent, bool i_listwork, const std::string & i_na
 	timer->start( 1000 * af::Environment::getWatchRefreshGuiSec());
 	connect( timer, SIGNAL( timeout()), this, SLOT( repaintItems()));
 
-	m_parentWindow->setWindowTitle("Jobs:");
+	this->setWindowTitleWithPrefix("Jobs:");
 }
 
 ListJobs::~ListJobs()
@@ -671,7 +671,7 @@ void ListJobs::calcTotals()
 
 	if (numjobs == 0)
 	{
-		m_parentWindow->setWindowTitle("Jobs: (none)");
+		this->setWindowTitleWithPrefix("Jobs: (none)");
 		return;
 	}
 
@@ -702,10 +702,10 @@ void ListJobs::calcTotals()
 		title += QString(" Run:%1 %2%").arg(running).arg(percent / blocksrun);
 		if (done)
 			title += QString(" Done:%1").arg(done);
-		m_parentWindow->setWindowTitle(title);
+		this->setWindowTitleWithPrefix(title);
 	}
 	else
-		m_parentWindow->setWindowTitle(QString("Jobs: %1 Done").arg(numjobs));
+		this->setWindowTitleWithPrefix(QString("Jobs: %1 Done").arg(numjobs));
 }
 
 void ListJobs::actMoveUp()     { moveJobs("move_jobs_up"    ); }

--- a/afanasy/src/watch/listmonitors.cpp
+++ b/afanasy/src/watch/listmonitors.cpp
@@ -61,7 +61,7 @@ ListMonitors::ListMonitors( QWidget* parent):
 	connect( bp, SIGNAL( sigClicked()), this, SLOT( actExit()));
 
 
-	m_parentWindow->setWindowTitle("Monitors");
+	this->setWindowTitleWithPrefix("Monitors");
 
 	initListNodes();
 }
@@ -154,7 +154,7 @@ void ListMonitors::calcTitle()
 		ItemMonitor * itemmonitor = static_cast<ItemMonitor*>(m_model->item(i));
 		if (itemmonitor->isSuperUser()) super++;
 	}
-	m_parentWindow->setWindowTitle(QString("Monitors: %1, Super users %2").arg(total).arg(super));
+	this->setWindowTitleWithPrefix(QString("Monitors: %1, Super users %2").arg(total).arg(super));
 }
 
 void ListMonitors::actSendMessage()

--- a/afanasy/src/watch/listrenders.cpp
+++ b/afanasy/src/watch/listrenders.cpp
@@ -188,7 +188,7 @@ ListRenders::ListRenders( QWidget* parent):
 		connect(bp, SIGNAL(sigClicked()), this, SLOT(actDelete()));
 	}
 
-	m_parentWindow->setWindowTitle("Renders");
+	this->setWindowTitleWithPrefix("Renders");
 
 	if (af::Environment::GOD())
 	{
@@ -751,7 +751,7 @@ void ListRenders::calcTitle()
 		}
 	}
 
-	m_parentWindow->setWindowTitle(
+	this->setWindowTitleWithPrefix(
 			QString("Farm: %1 On, %2 Busy, %3 Off, %4 Nimby, %5 Total, %6 Pools")
 			.arg(ronline).arg(rbusy).arg(roffline).arg(rnimby).arg(rtotal).arg(ptotal));
 }

--- a/afanasy/src/watch/listtasks.cpp
+++ b/afanasy/src/watch/listtasks.cpp
@@ -54,7 +54,7 @@ ListTasks::ListTasks( QWidget* parent, int JobId, const QString & JobName):
 //   view->setUniformItemSizes( true);
 //   view->setBatchSize( 10000);
 
-	m_parentWindow->setWindowTitle( m_job_name);
+	this->setWindowTitleWithPrefix( m_job_name);
 
 	getJobFullData();
 
@@ -662,7 +662,7 @@ void ListTasks::setWindowTitleProgress()
 			total_tasks++;
 		}
 
-	m_parentWindow->setWindowTitle( QString("%1% %2").arg(total_percent/total_tasks).arg(m_job_name));
+	this->setWindowTitleWithPrefix( QString("%1% %2").arg(total_percent/total_tasks).arg(m_job_name));
 }
 
 void ListTasks::actTaskOpen()

--- a/afanasy/src/watch/listusers.cpp
+++ b/afanasy/src/watch/listusers.cpp
@@ -117,7 +117,7 @@ ListUsers::ListUsers( QWidget* parent):
 	addParam_Hrs(Item::TUser, "jobs_life_time",            "Jobs Life Time",         "After this time job will be deleted");
 
 
-	m_parentWindow->setWindowTitle("Users");
+	this->setWindowTitleWithPrefix("Users");
 
 	initListNodes();
 
@@ -205,7 +205,7 @@ void ListUsers::calcTitle()
 		ItemUser * itemuser = static_cast<ItemUser*>(m_model->item(i));
 		if (itemuser->running_tasks_num > 0) running++;
 	}
-	m_parentWindow->setWindowTitle(QString("Users: %1, Running %2").arg(total).arg(running));
+	this->setWindowTitleWithPrefix(QString("Users: %1, Running %2").arg(total).arg(running));
 }
 
 void ListUsers::actDelete() { operation(Item::TUser, "delete"); }

--- a/afanasy/src/watch/listwork.cpp
+++ b/afanasy/src/watch/listwork.cpp
@@ -45,7 +45,7 @@ ListWork::ListWork(QWidget * i_parent):
 
 	m_hide_flags = ms_hide_flags;
 
-	m_parentWindow->setWindowTitle("Work");
+	this->setWindowTitleWithPrefix("Work");
 
 	// Add left panel buttons:
 	ButtonPanel * bp;
@@ -309,7 +309,7 @@ void ListWork::calcTitle()
 	else
 		jobs = QString("Jobs: %1 Done").arg(jtotal);
 
-	m_parentWindow->setWindowTitle(jobs + "; " + branches);
+	this->setWindowTitleWithPrefix(jobs + "; " + branches);
 }
 
 void ListWork::slot_ACC_Enable()   {setParameter(Item::TBranch, "create_childs", "true" );}


### PR DESCRIPTION
We deal with multiple servers and need a way to distinguish the different windows with which server it's connected to. I'm open for other ways to display this information.
It Could also be an argument to afwatch that defines the prefix and not just server name.