### PR TITLE
Expose block capacity to service python class

### DIFF
--- a/afanasy/src/libafanasy/service.cpp
+++ b/afanasy/src/libafanasy/service.cpp
@@ -208,6 +208,7 @@ void Service::initialize( const TaskExec * i_task_exec, const std::string & i_st
 	PyDict_SetItemString( task_info, "block_id",          PyLong_FromLong( i_task_exec->getBlockNum()));
 	PyDict_SetItemString( task_info, "block_name",        PyBytes_FromString( i_task_exec->getBlockName().c_str()));
 	PyDict_SetItemString( task_info, "block_flags",       PyLong_FromLong( i_task_exec->getBlockFlags()));
+    PyDict_SetItemString( task_info, "block_capacity",    PyLong_FromLong( i_task_exec->getCapacity()));
 	PyDict_SetItemString( task_info, "block_custom_data", PyBytes_FromString( i_task_exec->m_custom_data_block.c_str()));
 
 	PyDict_SetItemString( task_info, "job_id",          PyLong_FromLong( i_task_exec->getJobId()));

--- a/afanasy/src/libafanasy/service.cpp
+++ b/afanasy/src/libafanasy/service.cpp
@@ -208,7 +208,7 @@ void Service::initialize( const TaskExec * i_task_exec, const std::string & i_st
 	PyDict_SetItemString( task_info, "block_id",          PyLong_FromLong( i_task_exec->getBlockNum()));
 	PyDict_SetItemString( task_info, "block_name",        PyBytes_FromString( i_task_exec->getBlockName().c_str()));
 	PyDict_SetItemString( task_info, "block_flags",       PyLong_FromLong( i_task_exec->getBlockFlags()));
-    PyDict_SetItemString( task_info, "block_capacity",    PyLong_FromLong( i_task_exec->getCapacity()));
+	PyDict_SetItemString( task_info, "block_capacity",    PyLong_FromLong( i_task_exec->getCapacity()));
 	PyDict_SetItemString( task_info, "block_custom_data", PyBytes_FromString( i_task_exec->m_custom_data_block.c_str()));
 
 	PyDict_SetItemString( task_info, "job_id",          PyLong_FromLong( i_task_exec->getJobId()));


### PR DESCRIPTION
We use capacity as a means to block out memory usage and with this exposed to the task running we and monitor memory usage and compare it to capacity and stop running tasks that are using too much memory compared to it's capacity.