### PR TITLE
Fix for #611

### DIFF
--- a/afanasy/src/render/taskprocess.cpp
+++ b/afanasy/src/render/taskprocess.cpp
@@ -451,13 +451,19 @@ void TaskProcess::readProcess( const std::string & i_mode)
 
 	std::string output;
 
-	int readsize = readPipe( m_io_output);
-	if( readsize > 0 )
-		output = std::string( m_readbuffer, readsize);
+	int readsize = 0;
+	do {
+		readsize = readPipe( m_io_output);
+		if ( readsize > 0 )
+			output += std::string( m_readbuffer, readsize);
+	} while ( readsize > 0 );
 
-	readsize = readPipe( m_io_outerr);
-	if( readsize > 0 )
-		output += std::string( m_readbuffer, readsize);
+	do {
+		readsize = readPipe( m_io_outerr);
+		if ( readsize > 0 )
+			output += std::string( m_readbuffer, readsize);
+	} while ( readsize > 0 );
+
 
 	std::string resources;
 	resources += "{\n";


### PR DESCRIPTION
This change will read all the output from the render's process stdout and stderr in one rendercycle/heartbeat even if the buffer size is smaller than the output size of the render's stdout or stderr.