### PR TITLE
devel depends: allow passing custom parameters

### DIFF
--- a/utilities/install_depends_devel.sh
+++ b/utilities/install_depends_devel.sh
@@ -208,4 +208,4 @@ for package in $packages_noarch; do
 done
 
 echo $cmd
-$cmd
+$cmd "$@"


### PR DESCRIPTION
Allows passing parameters like "-y" or "--no-install-recommends" when using Debian/Ubuntu.