### PR TITLE
afanasy: delete copy and move operators of af::Msg

### DIFF
--- a/afanasy/src/libafanasy/msg.h
+++ b/afanasy/src/libafanasy/msg.h
@@ -241,5 +241,13 @@ private:
 
 	void rw_header( bool write); ///< Read or write message header.
 	void v_readwrite( Msg * msg);
+
+	// Delete copy constructor and copy assignment as they are not implemented
+	Msg(const Msg &) = delete;
+	Msg &operator=(const Msg &) = delete;
+
+	// Delete move constructor and move assignment as they are not implemented
+	Msg(Msg &&) = delete;
+	Msg &operator=(Msg &&) = delete;
 };
 }


### PR DESCRIPTION
While debugging, I accidentally used the copy assignment in a test which lead me down completely wrong rabbit hole.
Deleting them explicitely will throw compile errors in case they are being used somewhere.