### PR TITLE
Replace deprecated 'imp' with 'importlib'

### DIFF
--- a/plugins/blender/addons/cgru_tools/operators.py
+++ b/plugins/blender/addons/cgru_tools/operators.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import imp
+import importlib
 import time
 import os
 import sys


### PR DESCRIPTION
Blender 5.1 uses Python 3.13 which deprecated the usage of imp

The addon would no longer load in the latest versions of Blender main.