### PR TITLE
Add hostname to render resources JSON

### DIFF
--- a/afanasy/src/libafanasy/render.cpp
+++ b/afanasy/src/libafanasy/render.cpp
@@ -80,6 +80,7 @@ void Render::v_jsonWrite( std::ostringstream & o_str, int i_type) const // Threa
 	if( i_type == af::Msg::TRendersResources )
 	{
 		o_str << "\n\"id\":"   << m_id;
+		o_str << ",\n\"host_name\":\"" << m_name << "\"";
 		if( isOnline())
 		{
 			o_str << ",\n\"idle_time\":" << m_idle_time;


### PR DESCRIPTION
We needed to be able to get the hostname directly when querying the resources only to avoid a separate query to get all the renders just for the hostname

## Summary
- include render host name in `TRendersResources` JSON payload
- adds `"host_name"` next to existing `id` / resource fields

## Scope
- one-file change in `afanasy/src/libafanasy/render.cpp`
- no unrelated behavior changes
