### PR TITLE
Filter logged-in users to real login sessions

### DIFF
--- a/afanasy/src/render/res_linux.cpp
+++ b/afanasy/src/render/res_linux.cpp
@@ -428,9 +428,11 @@ void GetResources_LINUX(af::HostRes & hres, bool verbose)
    struct utmpx *user;
    while( (user = getutxent()) != NULL)
    {
-       std::string username = user->ut_user;
-       if (userignoreset.count(username) == 0)
-          userset.insert(username);
+      if (user->ut_type == USER_PROCESS) {
+         std::string username = user->ut_user;
+         if (userignoreset.count(username) == 0)
+               userset.insert(username);
+      }
    }
    endutxent();
    


### PR DESCRIPTION
## Why
In mixed production environments, Linux `utmp` can contain non-interactive/system entries in addition to real user sessions.
This can make the "logged in users" list noisy and less useful for operations.

## What
Filter Linux login records to include only `USER_PROCESS` entries before building `logged_in_users`.

## How
In `GetResources_LINUX` (`afanasy/src/render/res_linux.cpp`), the `getutxent()` loop now checks `user->ut_type == USER_PROCESS` and only then applies existing ignore filtering and inserts the username.
