### PR TITLE
Increase socket close wait timeout

### DIFF
--- a/afanasy/src/server/socketsprocessing.cpp
+++ b/afanasy/src/server/socketsprocessing.cpp
@@ -553,7 +553,7 @@ void SocketItem::checkClosed()
 		}
 	}
 
-	if( time(NULL) - m_wait_time > 2 )
+	if( time(NULL) - m_wait_time > 10 )
 	{
 		AF_WARN << "Client has NOT closed socket first: " << this;
 		closeSocket();
@@ -949,4 +949,3 @@ void SocketsProcessing::EpollDel( int i_sfd)
 	epoll_ctl( ms_this->m_epoll_fd, EPOLL_CTL_DEL, i_sfd, NULL);
 }
 #endif // LINUX
-


### PR DESCRIPTION
## Why
In production we observed frequent `Client has NOT closed socket first` warnings and related connection instability patterns.
Investigation in showed this was timing-sensitive, and the current server-side close wait threshold (`2s`) was too aggressive for some clients/environments, especially the windows clients / webuis

## What
Increase the server-side wait timeout in `SocketItem::checkClosed()` from `2` to `10` seconds before forcing socket close.

## How
Update the timeout condition in `afanasy/src/server/socketsprocessing.cpp`:
- before: `time(NULL) - m_wait_time > 2`
- after:  `time(NULL) - m_wait_time > 10`

This keeps existing close-check logic unchanged while giving slow clients enough time to complete close handshake.
