### PR TITLE
Add arm64 platform support and Ubuntu arm64 CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,39 @@ jobs:
         working-directory: afanasy/src/project.cmake
         run: ctest --test-dir . --output-on-failure
 
+  build-ubuntu-arm64:
+    name: Build Ubuntu 24.04 arm64
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            build-essential \
+            cmake \
+            git \
+            libpq-dev \
+            libzip-dev \
+            python3 \
+            python3-dev \
+            qtbase5-dev \
+            qtmultimedia5-dev
+
+      - name: Build (SQL + GUI)
+        working-directory: afanasy/src/project.cmake
+        run: |
+          set -euo pipefail
+          ./clear.py
+          ./build.sh --quiet -j"$(nproc)"
+
+      - name: Run CTest
+        working-directory: afanasy/src/project.cmake
+        run: ctest --test-dir . --output-on-failure
+
   build-linux-container:
     name: Build ${{ matrix.name }}
     runs-on: ubuntu-24.04

--- a/afanasy/src/libafanasy/common/dlMutex.h
+++ b/afanasy/src/libafanasy/common/dlMutex.h
@@ -47,7 +47,7 @@ private:
 #elif defined(LINUX) || defined(BSD)
 #if defined(__x86_64__) || defined(__powerpc64__)
 	unsigned m_data[10];
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) || defined(__arm64__) || defined(__LP64__) || defined(_LP64)
 	unsigned m_data[16];
 #else
 	unsigned m_data[6];
@@ -63,4 +63,3 @@ private:
 };
 
 #endif // __dlMutex_h
-

--- a/afanasy/src/libafanasy/platform_info.cpp
+++ b/afanasy/src/libafanasy/platform_info.cpp
@@ -288,11 +288,22 @@ std::vector<std::string> af::platformGetTokens()
 	addUniqueToken(tokens, "linux");
 #endif
 
+	bool bitness_known = false;
 	switch( sizeof(void*))
 	{
-	case 4: addUniqueToken(tokens, "32"); break;
-	case 8: addUniqueToken(tokens, "64"); break;
+	case 4:
+		addUniqueToken(tokens, "32");
+		bitness_known = true;
+		break;
+	case 8:
+		addUniqueToken(tokens, "64");
+		bitness_known = true;
+		break;
 	}
+#if defined(__aarch64__)
+	if( bitness_known == false)
+		addUniqueToken(tokens, "arm64");
+#endif
 
 	std::string name_token;
 	std::string version_token;

--- a/afanasy/src/libafanasy/platform_info.cpp
+++ b/afanasy/src/libafanasy/platform_info.cpp
@@ -288,21 +288,20 @@ std::vector<std::string> af::platformGetTokens()
 	addUniqueToken(tokens, "linux");
 #endif
 
-	bool bitness_known = false;
+#if defined(__aarch64__) || defined(__arm64__)
+	addUniqueToken(tokens, "aarch64");
+#elif defined(__arm__)
+	addUniqueToken(tokens, "arm32");
+#else
 	switch( sizeof(void*))
 	{
 	case 4:
 		addUniqueToken(tokens, "32");
-		bitness_known = true;
 		break;
 	case 8:
 		addUniqueToken(tokens, "64");
-		bitness_known = true;
 		break;
 	}
-#if defined(__aarch64__)
-	if( bitness_known == false)
-		addUniqueToken(tokens, "arm64");
 #endif
 
 	std::string name_token;

--- a/afanasy/src/project.cmake/tests/platform_info_integration_tests.cpp
+++ b/afanasy/src/project.cmake/tests/platform_info_integration_tests.cpp
@@ -209,6 +209,13 @@ bool testTokenVectorIntegration()
 		return false;
 #endif
 
+#if defined(__aarch64__) || defined(__arm64__)
+	if( false == expect(hasToken(tokens, "aarch64"), "aarch64 token should be present"))
+		return false;
+#elif defined(__arm__)
+	if( false == expect(hasToken(tokens, "arm32"), "arm32 token should be present"))
+		return false;
+#else
 	if( sizeof(void*) == 4 )
 	{
 		if( false == expect(hasToken(tokens, "32"), "32 token should be present"))
@@ -219,6 +226,7 @@ bool testTokenVectorIntegration()
 		if( false == expect(hasToken(tokens, "64"), "64 token should be present"))
 			return false;
 	}
+#endif
 
 	std::string name;
 	std::string version;

--- a/afanasy/src/render/res_linux.cpp
+++ b/afanasy/src/render/res_linux.cpp
@@ -31,6 +31,10 @@
 	Various helper funcuntions.
 */
 static float get_cpu_frequency();
+static bool read_cpuinfo_value( const char * i_buffer, const char * i_key, float & o_value );
+#if defined(__aarch64__) || defined(__arm64__) || defined(__arm__)
+static bool read_cpufreq_khz_file( const char * i_file_name, float & o_value_mhz );
+#endif
 static void get_disk_stats();
 static long get_sector_size();
 static bool get_network_statistics(
@@ -463,18 +467,57 @@ static float get_cpu_frequency( )
 
    while( fgets(buffer, sizeof(buffer)-1, cpufd) )
    {
-      if( strncmp(buffer, "cpu MHz", 7) != 0 )
-         continue;
-
       float cpu_frequency;
-      int items = sscanf( buffer, "cpu MHz\t: %f\n", &cpu_frequency );
-
-      if( items == 1 )
+      if( read_cpuinfo_value( buffer, "cpu MHz", cpu_frequency ) )
       {
          fclose( cpufd );
          return cpu_frequency;
       }
    }
+
+#if defined(__aarch64__) || defined(__arm64__) || defined(__arm__)
+   // On heterogeneous ARM (big.LITTLE), cpu0 may be a small/slow core.
+   // Iterate all CPUs, reading the first available sysfs freq file for each,
+   // and return the highest frequency seen across all cores.
+   static const char * freq_suffixes[] =
+   {
+      "cpuinfo_max_freq",
+      "scaling_max_freq",
+      "scaling_cur_freq"
+   };
+
+   float max_freq = 0.0f;
+   char freq_path[256];
+
+   int cpu_count = int(sysconf(_SC_NPROCESSORS_CONF));
+   if( cpu_count < 1 )
+      cpu_count = int(sysconf(_SC_NPROCESSORS_ONLN));
+   if( cpu_count < 1 )
+      cpu_count = 1;
+
+   for( int cpu = 0; cpu < cpu_count; cpu++ )
+   {
+      for( unsigned s = 0; s < (sizeof(freq_suffixes) / sizeof(freq_suffixes[0])); s++ )
+      {
+         snprintf( freq_path, sizeof(freq_path),
+            "/sys/devices/system/cpu/cpu%d/cpufreq/%s", cpu, freq_suffixes[s] );
+         float cpu_frequency;
+         if( read_cpufreq_khz_file( freq_path, cpu_frequency ) )
+         {
+            if( cpu_frequency > max_freq )
+               max_freq = cpu_frequency;
+            break;
+         }
+      }
+   }
+
+   if( max_freq > 0.0f )
+   {
+      fclose( cpufd );
+      return max_freq;
+   }
+
+#endif
  
    fprintf( stderr, "couldn't find cpu frequency in '/proc/cpuinfo' file.\n" );
 
@@ -482,6 +525,51 @@ static float get_cpu_frequency( )
 
    return 2000;
 }
+
+static bool read_cpuinfo_value( const char * i_buffer, const char * i_key, float & o_value )
+{
+   size_t key_length = strlen( i_key );
+   if( strncmp(i_buffer, i_key, key_length) != 0 )
+      return false;
+
+   char next = i_buffer[key_length];
+   if( next != '\0' && next != ' ' && next != '\t' && next != ':' )
+      return false;
+
+   const char * value_pos = i_buffer + key_length;
+   while( (*value_pos == ' ') || (*value_pos == '\t') )
+      value_pos++;
+
+   if( *value_pos != ':' )
+      return false;
+
+   value_pos++;
+   while( (*value_pos == ' ') || (*value_pos == '\t') )
+      value_pos++;
+
+   return sscanf( value_pos, "%f", &o_value ) == 1;
+}
+
+#if defined(__aarch64__) || defined(__arm64__) || defined(__arm__)
+static bool read_cpufreq_khz_file( const char * i_file_name, float & o_value_mhz )
+{
+   FILE * file = ::fopen( i_file_name, "r" );
+   if( file == NULL )
+      return false;
+
+   unsigned long frequency_khz = 0;
+   int items = fscanf( file, "%lu", &frequency_khz );
+   fclose( file );
+
+   if( (items == 1) && (frequency_khz > 0) )
+   {
+      o_value_mhz = float(frequency_khz) / 1000.0f;
+      return true;
+   }
+
+   return false;
+}
+#endif
 
 static double
 compute_etime(struct timeval cur_time, struct timeval prev_time)


### PR DESCRIPTION
We have started running afrender on a Nvidia Spark DGX, which is ARM based

## Summary
- add arm64-safe token handling in platform detection (`platform_info.cpp`)
- extend `DlMutex` storage sizing guards for arm64/LP64 builds (`dlMutex.h`)
- add GitHub Actions job `build-ubuntu-arm64` on `ubuntu-24.04-arm`

