### PR TITLE
Use f_bavail for Linux HDD free reporting

### DIFF
--- a/afanasy/src/render/res_linux.cpp
+++ b/afanasy/src/render/res_linux.cpp
@@ -294,8 +294,9 @@ void GetResources_LINUX(af::HostRes & hres, bool verbose)
       }
       else
       {
-         hres.hdd_total_gb = ((fsd.f_blocks >> 10) * fsd.f_bsize) >> 20;
-         hres.hdd_free_gb  = ((fsd.f_bfree  >> 10) * fsd.f_bsize) >> 20;
+         hres.hdd_total_gb = ((fsd.f_blocks  >> 10) * fsd.f_bsize) >> 20;
+         // Use user-available blocks, excluding root-reserved space.
+         hres.hdd_free_gb  = ((fsd.f_bavail >> 10) * fsd.f_bsize) >> 20;
       }
 
       // io:


### PR DESCRIPTION
## Summary
- on Linux, switch free disk reporting from `statfs.f_bfree` to `statfs.f_bavail`
- keep total disk reporting unchanged (`f_blocks`)

## Why
Issue #591 reports that Afanasy shows more free disk space than `df -h`.

`f_bfree` includes filesystem blocks reserved for root. Render processes running as regular users cannot use that reserved space, so Afanasy was over-reporting usable free space.

`f_bavail` reports blocks available to unprivileged processes, which matches user-facing free space and task write reality.

Fixes #591.

## Scheduling / Behavioral Implications
- `hdd_free_gb` on Linux will be lower by approximately the reserved-block amount.
- Scheduling checks using `need_hdd` become more accurate (fewer tasks dispatched to hosts that are effectively full for render users).
- Disk-based overload/idle thresholds may trigger earlier on low-space hosts, reflecting real writable space.
- No protocol/schema changes; same field (`hdd_free_gb`), corrected semantics on Linux only.

## Validation
- compiled successfully in `afanasy/src/project.cmake` after `./clear.py` and `make -j"$(nproc)"`
- `ctest --test-dir . --output-on-failure` passed (2/2)
